### PR TITLE
Add fulfillment minimum lawful slice

### DIFF
--- a/docs/FULFILLMENT_KERNEL.md
+++ b/docs/FULFILLMENT_KERNEL.md
@@ -1,0 +1,30 @@
+# Fulfillment Kernel — Minimum Lawful Slice
+
+> Every meaning-bearing object may expose a lawful path into embodied care. Fulfillment records what crossed that seam without claiming moral completion, compelling disclosure, or closing future authorship.
+
+## Stable canon
+
+- A receipt records a real-world response, not proof of success.
+- A witness preserves a claim; it does not certify moral worth or objective truth.
+- Fulfillment answers only a scoped Need.
+- Canonical events and derived projections never exchange roles.
+- Missing provenance may remain unknown, but may never be silently invented.
+- The child remains the telos without becoming telemetry.
+
+## Technical claim
+
+The system can preserve a stable, attributable, disclosure-bounded claim that a scoped material response was reported to have crossed into reality.
+
+## Fixture discipline
+
+Draft fixtures live in `fixtures/drafts/` and may omit `canonicalHash`.
+Canonical fixtures live in `fixtures/canonical/`, must contain a real SHA-256 hash, and must pass `npm run verify:fixtures`.
+A fixture is not a live Need. Live Needs require an authorized circle, accountable recorder, and real scoped request.
+
+## Canonical versus derived
+
+Canonical objects: `NEED_DECLARED`, `OFFER_DECLARED`, `JOIN_DECLARED`, `FULFILLMENT_RECORDED`, `WITNESS_RECORDED`, `COUNTER_WITNESS_RECORDED`, `PROVENANCE_LINK_RECORDED`, `NEED_PAUSED`, `NEED_WITHDRAWN`, `SOIL_RECORDED`.
+
+Derived views: `NeedProjection`, `StillCallingProjection`, `PublicAggregateProjection`, `MorningAuditProjection`.
+
+Hashing provides content identity and tamper evidence. Signing attributes submission. Witnessing records an observation. None independently proves the underlying real-world claim.

--- a/fixtures/canonical/need_breakfast_001.json
+++ b/fixtures/canonical/need_breakfast_001.json
@@ -1,0 +1,30 @@
+{
+  "canonicalHash": "sha256:fbf5737f8edb7f77637648b5b7810c73647ae46e62d0a8ffe7d225ec71a4c5ec",
+  "createdAt": "2026-07-31T00:00:00Z",
+  "createdBy": "actor_fixture",
+  "disclosurePolicy": {
+    "audience": "circle",
+    "basis": "aggregate_only",
+    "permittedFields": {
+      "artifacts": false,
+      "coarsePlace": true,
+      "coarseTime": true,
+      "exactPlace": false,
+      "participantIdentity": false,
+      "quantity": true,
+      "summary": true
+    }
+  },
+  "environment": "test",
+  "id": "fixture_need_breakfast_001",
+  "kind": "meal",
+  "note": "Fixture only - not a live Need. Live Need requires authorized circle, accountable recorder, scoped request.",
+  "requestedQuantity": {
+    "unit": "meal",
+    "value": 33
+  },
+  "summary": "Breakfast capacity requested for a local morning meal table.",
+  "type": "NEED_DECLARED",
+  "version": 1,
+  "visibility": "circle"
+}

--- a/fixtures/drafts/need_breakfast_001.draft.json
+++ b/fixtures/drafts/need_breakfast_001.draft.json
@@ -1,0 +1,29 @@
+{
+  "createdAt": "2026-07-31T00:00:00Z",
+  "createdBy": "actor_fixture",
+  "disclosurePolicy": {
+    "audience": "circle",
+    "basis": "aggregate_only",
+    "permittedFields": {
+      "artifacts": false,
+      "coarsePlace": true,
+      "coarseTime": true,
+      "exactPlace": false,
+      "participantIdentity": false,
+      "quantity": true,
+      "summary": true
+    }
+  },
+  "environment": "test",
+  "id": "fixture_need_breakfast_001",
+  "kind": "meal",
+  "note": "Fixture only - not a live Need. Live Need requires authorized circle, accountable recorder, scoped request.",
+  "requestedQuantity": {
+    "unit": "meal",
+    "value": 33
+  },
+  "summary": "Breakfast capacity requested for a local morning meal table.",
+  "type": "NEED_DECLARED",
+  "version": 1,
+  "visibility": "circle"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@the-static-collective/tranchnode",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "mint:fixture": "node --experimental-strip-types scripts/mint-fixture.ts",
+    "verify:fixtures": "node --experimental-strip-types scripts/verify-fixtures.ts",
+    "test": "node --experimental-strip-types --test tests/*.test.ts",
+    "check": "npm run verify:fixtures && npm test"
+  },
+  "engines": {
+    "node": ">=22.6.0"
+  }
+}

--- a/scripts/mint-fixture.ts
+++ b/scripts/mint-fixture.ts
@@ -1,0 +1,13 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { canonicalizeAndHash } from "../src/tranchnode/canonicalize.ts";
+
+const input = process.argv[2];
+if (!input) throw new Error("usage: npm run mint:fixture -- <draft.json> [output.json]");
+const draft = JSON.parse(await readFile(input, "utf8")) as Record<string, unknown>;
+delete draft.canonicalHash;
+const { hash } = await canonicalizeAndHash(draft);
+const output = process.argv[3] ?? join("fixtures/canonical", basename(input).replace(/\.draft\.json$/, ".json"));
+await mkdir(dirname(output), { recursive: true });
+await writeFile(output, JSON.stringify({ ...draft, canonicalHash: hash }, null, 2) + "\n");
+console.log(`${output}: ${hash}`);

--- a/scripts/verify-fixtures.ts
+++ b/scripts/verify-fixtures.ts
@@ -1,0 +1,35 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { canonicalizeAndHash } from "../src/tranchnode/canonicalize.ts";
+
+async function discover(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...await discover(path));
+    else if (entry.isFile() && entry.name.endsWith(".json")) out.push(path);
+  }
+  return out;
+}
+
+const explicit = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+const paths = explicit.length ? explicit : await discover("fixtures/canonical");
+let failed = false;
+for (const path of paths) {
+  const record = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+  const stored = record.canonicalHash;
+  if (typeof stored !== "string" || !/^sha256:[0-9a-f]{64}$/.test(stored)) {
+    console.error(`${path}: missing, malformed, or placeholder canonicalHash`);
+    failed = true;
+    continue;
+  }
+  const first = await canonicalizeAndHash(record);
+  const second = await canonicalizeAndHash(record);
+  if (first.hash !== second.hash || first.hash !== stored) {
+    console.error(`${path}: expected ${stored}; computed ${first.hash}; repeat ${second.hash}`);
+    failed = true;
+  } else {
+    console.log(`${path}: verified ${stored}`);
+  }
+}
+if (failed) process.exitCode = 1;

--- a/src/tranchnode/canonicalize.ts
+++ b/src/tranchnode/canonicalize.ts
@@ -1,0 +1,39 @@
+import { CANONICALIZATION_VERSION } from "./ontology/fulfillment.ts";
+import type { ContentHash } from "./ontology/fulfillment.ts";
+
+export const CANONICALIZATION_VERSION_CURRENT = CANONICALIZATION_VERSION;
+
+function assertFiniteNumber(n: unknown): void {
+  if (typeof n !== "number" || !Number.isFinite(n)) throw new Error(`non-finite number forbidden in canonical payload: ${n}`);
+}
+function normalizeString(s: string): string { return s.normalize("NFC"); }
+function canonicalizeValue(value: unknown): unknown {
+  if (value === undefined) throw new Error("undefined forbidden in canonical payload - omit key instead");
+  if (value === null) return null;
+  if (typeof value === "number") { assertFiniteNumber(value); return value; }
+  if (typeof value === "string") return normalizeString(value);
+  if (typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(canonicalizeValue);
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).filter((k) => k !== "canonicalHash").sort()) {
+      if (obj[key] === undefined) throw new Error(`undefined value for key ${key} - must be omitted`);
+      out[key] = canonicalizeValue(obj[key]);
+    }
+    return out;
+  }
+  throw new Error(`unsupported type in canonical payload: ${typeof value}`);
+}
+export function canonicalize<T>(payload: T) {
+  const envelope = { canonicalizationVersion: CANONICALIZATION_VERSION_CURRENT, payload: canonicalizeValue(payload) };
+  return { bytes: JSON.stringify(envelope), envelope };
+}
+export async function hashCanonical(bytes: string): Promise<ContentHash> {
+  const { createHash } = await import("node:crypto");
+  return `sha256:${createHash("sha256").update(bytes, "utf8").digest("hex")}`;
+}
+export async function canonicalizeAndHash<T>(payload: T): Promise<{ bytes: string; hash: ContentHash }> {
+  const { bytes } = canonicalize(payload);
+  return { bytes, hash: await hashCanonical(bytes) };
+}

--- a/src/tranchnode/ontology/fulfillment.ts
+++ b/src/tranchnode/ontology/fulfillment.ts
@@ -1,0 +1,66 @@
+// fulfillment.ts - tightened minimum ontology
+// Canon:
+// - A receipt records a real-world response, not proof of success
+// - A witness preserves a claim, not moral worth
+// - Fulfillment answers only a scoped Need
+// - Canonical events and derived projections never exchange roles
+// - Missing provenance may remain unknown, never silently invented
+// - Child remains telos without becoming telemetry
+
+export type EntityId = string;
+export type ISO8601 = string;
+export type ContentHash = `sha256:${string}`;
+
+export type Quantity = { value: number; unit: string };
+export type Visibility = "private" | "participants" | "circle" | "public";
+export type FulfillmentKind = "meal" | "grocery" | "childcare" | "tutoring" | "repair" | "transport" | "oral_history" | "planting" | "other";
+export type FulfillmentOutcome = "attempted" | "partial" | "scoped_complete" | "scope_uncertain";
+export type FulfillmentOrigin = "joined_offer" | "direct_response" | "external" | "unknown";
+
+export interface DisclosurePolicy {
+  audience: Visibility;
+  permittedFields: { summary: boolean; quantity: boolean; coarseTime: boolean; coarsePlace: boolean; exactPlace: boolean; participantIdentity: boolean; artifacts: boolean };
+  basis: "participant_authorized" | "recorder_only" | "aggregate_only" | "public_event" | "withheld";
+}
+export interface ExternalProvenance { system?: string; sourceRef: string; sourceHash?: ContentHash }
+export const CANONICALIZATION_VERSION = 1 as const;
+export interface CanonicalEnvelope<T> { canonicalizationVersion: typeof CANONICALIZATION_VERSION; payload: T }
+
+export interface NeedDeclared {
+  id: EntityId; type: "NEED_DECLARED"; version: 1; createdAt: ISO8601; createdBy: EntityId; visibility: Visibility;
+  summary: string; kind: FulfillmentKind; requestedQuantity?: Quantity; disclosurePolicy: DisclosurePolicy; canonicalHash: ContentHash;
+}
+export interface OfferDeclared {
+  id: EntityId; type: "OFFER_DECLARED"; version: 1; createdAt: ISO8601; createdBy: EntityId; inspiredBy?: EntityId;
+  summary: string; kind?: FulfillmentKind; offeredQuantity?: Quantity; visibility: Visibility; disclosurePolicy: DisclosurePolicy; canonicalHash: ContentHash;
+}
+export interface JoinDeclared {
+  id: EntityId; type: "JOIN_DECLARED"; version: 1; needId: EntityId; offerId: EntityId; needSnapshotHash: ContentHash;
+  offerSnapshotHash: ContentHash; joinedQuantity?: Quantity; occurredAt: ISO8601; recordedAt: ISO8601; recordedBy: EntityId; canonicalHash: ContentHash;
+}
+export interface FulfillmentRecorded {
+  id: EntityId; type: "FULFILLMENT_RECORDED"; version: 1; needId: EntityId; needSnapshotHash: ContentHash;
+  offerId?: EntityId; offerSnapshotHash?: ContentHash; offerIds?: EntityId[]; joinId?: EntityId; origin: FulfillmentOrigin;
+  externalProvenance?: ExternalProvenance; outcome: FulfillmentOutcome; occurredAt: ISO8601; recordedAt: ISO8601; recordedBy: EntityId;
+  fulfillment: { kind: FulfillmentKind; summary: string; quantity?: Quantity };
+  visibility: Visibility; disclosurePolicy: DisclosurePolicy; canonicalHash: ContentHash;
+}
+export interface WitnessRecorded {
+  id: EntityId; type: "WITNESS_RECORDED"; version: 1; subjectId: EntityId; mode: "self_attested" | "participant" | "third_party" | "artifact";
+  statement?: string; artifactRefs?: string[]; witnessedAt?: ISO8601; recordedAt: ISO8601; recordedBy: EntityId; visibility: Visibility;
+  disclosurePolicy?: DisclosurePolicy; canonicalHash: ContentHash;
+}
+export interface CounterWitnessRecorded { id: EntityId; type: "COUNTER_WITNESS_RECORDED"; version: 1; subjectWitnessId: EntityId; statement: string; recordedAt: ISO8601; recordedBy: EntityId; visibility: Visibility; canonicalHash: ContentHash }
+export interface ProvenanceLinkRecorded { id: EntityId; type: "PROVENANCE_LINK_RECORDED"; version: 1; fromId: EntityId; toId: EntityId; relation: "CLARIFIES_ORIGIN" | "CONNECTS_EXTERNAL" | "SUPERSEDES"; note?: string; recordedAt: ISO8601; recordedBy: EntityId; canonicalHash: ContentHash }
+export interface NeedPaused { id: EntityId; type: "NEED_PAUSED"; version: 1; needId: EntityId; needSnapshotHash: ContentHash; reason?: string; pausedAt: ISO8601; recordedAt: ISO8601; recordedBy: EntityId; canonicalHash: ContentHash }
+export interface NeedWithdrawn { id: EntityId; type: "NEED_WITHDRAWN"; version: 1; needId: EntityId; needSnapshotHash: ContentHash; reason?: string; withdrawnAt: ISO8601; recordedAt: ISO8601; recordedBy: EntityId; canonicalHash: ContentHash }
+export interface SoilRecorded { id: EntityId; type: "SOIL_RECORDED"; version: 1; subjectId: EntityId; reason: "fulfilled" | "composted" | "monumented" | "withdrawn"; note?: string; recordedAt: ISO8601; recordedBy: EntityId; canonicalHash: ContentHash }
+
+export interface NeedProjection {
+  needId: EntityId; requestedQuantity?: Quantity; fulfilledQuantity?: Quantity; remainingQuantity?: Quantity; fulfillmentCount: number;
+  status: "open" | "paused" | "partially_answered" | "scope_answered" | "withdrawn" | "unknown";
+  stillCalling: boolean; confidence: "known" | "partial" | "unknown"; lastFulfillmentId?: EntityId; derivedAt: ISO8601;
+}
+export interface StillCallingProjection { needId: EntityId; stillCalling: boolean; remainingQuantity?: Quantity; derivedAt: ISO8601 }
+export interface PublicAggregateProjection { window: { from: ISO8601; to: ISO8601 }; mealsProvided: number; requestsAnswered: number; openScopes: number; outcomeUnknown: number; derivedAt: ISO8601 }
+export interface MorningAuditProjection { date: string; householdRequestsAnswered: number; mealsMateriallyProvided: number; openMealScopes: number; outcomeUnknown: number; newOffers: number; witnessesRecorded: number; harvestsGenerated: number; continuityPreserved: boolean; derivedAt: ISO8601 }

--- a/src/tranchnode/projectNeed.ts
+++ b/src/tranchnode/projectNeed.ts
@@ -1,0 +1,46 @@
+import type { FulfillmentRecorded, NeedDeclared, NeedProjection, ISO8601 } from "./ontology/fulfillment.ts";
+
+export function deriveProjectionConfidence(need: NeedDeclared, fulfillments: readonly FulfillmentRecorded[]): "known" | "partial" | "unknown" {
+  if (!need.requestedQuantity) return "unknown";
+  const applicable = fulfillments.filter((r) => r.outcome !== "attempted");
+  if (applicable.some((r) => !r.fulfillment.quantity || r.fulfillment.quantity.unit !== need.requestedQuantity!.unit || r.outcome === "scope_uncertain")) return "partial";
+  return "known";
+}
+
+export function projectNeed(
+  need: NeedDeclared,
+  fulfillments: readonly FulfillmentRecorded[],
+  lifecycle: readonly { type: string; recordedAt: ISO8601 }[] = [],
+  now: ISO8601 = new Date().toISOString(),
+): NeedProjection {
+  const requested = need.requestedQuantity;
+  let fulfilledValue = 0;
+  let unit = requested?.unit;
+  for (const fulfillment of fulfillments) {
+    if (fulfillment.outcome === "attempted") continue;
+    if (fulfillment.fulfillment.quantity?.unit === requested?.unit) {
+      fulfilledValue += fulfillment.fulfillment.quantity.value;
+      unit = fulfillment.fulfillment.quantity.unit;
+    }
+  }
+  const fulfilledQuantity = requested ? { value: fulfilledValue, unit: unit! } : undefined;
+  const remainingQuantity = requested && fulfilledQuantity ? { value: Math.max(0, requested.value - fulfilledQuantity.value), unit: requested.unit } : undefined;
+  let status: NeedProjection["status"] = "open";
+  const lastLifecycle = lifecycle.at(-1);
+  if (lastLifecycle?.type === "NEED_PAUSED") status = "paused";
+  else if (lastLifecycle?.type === "NEED_WITHDRAWN") status = "withdrawn";
+  else if (remainingQuantity?.value === 0) status = "scope_answered";
+  else if (fulfilledValue > 0) status = "partially_answered";
+  return {
+    needId: need.id,
+    requestedQuantity: requested,
+    fulfilledQuantity,
+    remainingQuantity,
+    fulfillmentCount: fulfillments.length,
+    status,
+    stillCalling: status === "open" || status === "partially_answered",
+    confidence: deriveProjectionConfidence(need, fulfillments),
+    lastFulfillmentId: fulfillments.at(-1)?.id,
+    derivedAt: now,
+  };
+}

--- a/src/tranchnode/validateFulfillment.ts
+++ b/src/tranchnode/validateFulfillment.ts
@@ -1,0 +1,49 @@
+import type { FulfillmentRecorded } from "./ontology/fulfillment.ts";
+
+function requireCond(cond: boolean, msg: string): void { if (!cond) throw new Error(msg); }
+function forbidCond(cond: boolean, msg: string): void { if (cond) throw new Error(msg); }
+
+export function validateFulfillmentReceipt(r: FulfillmentRecorded): void {
+  requireCond(!!r.needId, "needId required");
+  requireCond(!!r.needSnapshotHash, "needSnapshotHash required");
+  requireCond(!!r.outcome, "outcome required");
+  requireCond(!!r.origin, "origin required");
+  requireCond(!!r.fulfillment?.kind, "fulfillment.kind required");
+  requireCond(!!r.fulfillment?.summary, "fulfillment.summary required");
+  requireCond(!!r.disclosurePolicy, "disclosurePolicy required");
+
+  const hasJoin = !!r.joinId;
+  const hasOfferIds = !!r.offerIds?.length;
+  const hasOfferId = !!r.offerId;
+  const hasExternal = !!r.externalProvenance;
+
+  switch (r.origin) {
+    case "joined_offer":
+      requireCond(hasJoin, "joined_offer origin requires joinId");
+      forbidCond(hasExternal, "joined_offer must not have externalProvenance");
+      break;
+    case "direct_response":
+      forbidCond(hasJoin, "direct_response must not have joinId");
+      forbidCond(hasOfferIds, "direct_response must not have offerIds");
+      forbidCond(hasOfferId, "direct_response should not claim offerId - it answered need directly");
+      forbidCond(hasExternal, "direct_response must not have externalProvenance");
+      break;
+    case "external":
+      requireCond(hasExternal, "external origin requires externalProvenance");
+      requireCond(!!r.externalProvenance?.sourceRef, "externalProvenance.sourceRef required");
+      forbidCond(hasJoin, "external must not have joinId - link later via PROVENANCE_LINK_RECORDED");
+      break;
+    case "unknown":
+      forbidCond(hasJoin, "unknown origin must not have joinId");
+      forbidCond(hasOfferIds, "unknown origin must not have offerIds");
+      forbidCond(hasOfferId, "unknown origin must not have offerId");
+      forbidCond(hasExternal, "unknown origin must not have externalProvenance");
+      break;
+  }
+}
+
+export function validateNeedDeclared(n: Record<string, unknown>): void {
+  if ("status" in n) throw new Error("NeedDeclared must not contain status - status belongs in NeedProjection or lifecycle events");
+  if ("stillCalling" in n) throw new Error("NeedDeclared must not contain stillCalling - derived only");
+  if ("subjectConsent" in n) throw new Error("subjectConsent is forbidden - use disclosurePolicy.permittedFields and basis");
+}

--- a/tests/canonicalize.test.ts
+++ b/tests/canonicalize.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { canonicalize, canonicalizeAndHash } from "../src/tranchnode/canonicalize.ts";
+
+test("canonicalization ignores key insertion order and canonicalHash", async () => {
+  const a = { id: "1", summary: "meal", requestedQuantity: { value: 33, unit: "meal" } };
+  const b = { canonicalHash: "sha256:ignored", requestedQuantity: { unit: "meal", value: 33 }, summary: "meal", id: "1" };
+  assert.equal(canonicalize(a).bytes, canonicalize(b).bytes);
+  assert.equal((await canonicalizeAndHash(a)).hash, (await canonicalizeAndHash(b)).hash);
+});
+
+test("canonicalization rejects undefined and non-finite numbers", () => {
+  assert.throws(() => canonicalize({ x: undefined }), /undefined/);
+  assert.throws(() => canonicalize({ x: Number.NaN }), /non-finite/);
+});

--- a/tests/fixture-integrity.test.ts
+++ b/tests/fixture-integrity.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fixture from "../fixtures/canonical/need_breakfast_001.json" with { type: "json" };
+import { canonicalizeAndHash } from "../src/tranchnode/canonicalize.ts";
+
+test("canonical fixture is hash-complete", async () => {
+  assert.match(fixture.canonicalHash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal((await canonicalizeAndHash(fixture)).hash, fixture.canonicalHash);
+});

--- a/tests/fulfillment-lineage.test.ts
+++ b/tests/fulfillment-lineage.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateFulfillmentReceipt, validateNeedDeclared } from "../src/tranchnode/validateFulfillment.ts";
+
+const base: any = {
+  needId: "need_001",
+  needSnapshotHash: "sha256:abc",
+  outcome: "partial",
+  fulfillment: { kind: "meal", summary: "test" },
+  occurredAt: "2026-07-31",
+  recordedAt: "2026-07-31T20:00:00Z",
+  recordedBy: "actor_1",
+  visibility: "circle",
+  disclosurePolicy: {
+    audience: "circle",
+    permittedFields: { summary: true, quantity: true, coarseTime: true, coarsePlace: false, exactPlace: false, participantIdentity: false, artifacts: false },
+    basis: "aggregate_only"
+  }
+};
+
+test("canonical Need excludes derived fields", () => {
+  assert.throws(() => validateNeedDeclared({ id: "n1", status: "open" }), /status/);
+  assert.throws(() => validateNeedDeclared({ id: "n1", subjectConsent: "not_required" }), /subjectConsent/);
+});
+
+test("joined_offer requires joinId", () => {
+  assert.throws(() => validateFulfillmentReceipt({ ...base, origin: "joined_offer" }), /joinId/);
+  assert.doesNotThrow(() => validateFulfillmentReceipt({ ...base, origin: "joined_offer", joinId: "join_1" }));
+});
+
+test("direct_response excludes Offer provenance", () => {
+  assert.throws(() => validateFulfillmentReceipt({ ...base, origin: "direct_response", offerId: "offer_1" }), /offerId/);
+  assert.doesNotThrow(() => validateFulfillmentReceipt({ ...base, origin: "direct_response" }));
+});
+
+test("unknown origin excludes invented provenance", () => {
+  assert.throws(() => validateFulfillmentReceipt({ ...base, origin: "unknown", joinId: "join_1" }), /joinId/);
+});

--- a/tests/need-projection.test.ts
+++ b/tests/need-projection.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { projectNeed, deriveProjectionConfidence } from "../src/tranchnode/projectNeed.ts";
+
+test("projection derives remaining scope without mutation", () => {
+  const need: any = { id: "fixture_need_breakfast_001", requestedQuantity: { value: 33, unit: "meal" } };
+  const fulfillments: any[] = [{ id: "f1", outcome: "partial", fulfillment: { quantity: { value: 22, unit: "meal" } } }];
+  const original = JSON.stringify({ need, fulfillments });
+  const projection = projectNeed(need, fulfillments, [], "2026-07-31T21:00:00Z");
+  assert.equal(projection.fulfilledQuantity?.value, 22);
+  assert.equal(projection.remainingQuantity?.value, 11);
+  assert.equal(projection.stillCalling, true);
+  assert.equal(projection.status, "partially_answered");
+  assert.equal(projection.confidence, "known");
+  assert.equal(JSON.stringify({ need, fulfillments }), original);
+});
+
+test("confidence describes computability, not witness count", () => {
+  const need: any = { requestedQuantity: { value: 1, unit: "repair" } };
+  const uncertain: any[] = [{ outcome: "scope_uncertain", fulfillment: {} }];
+  assert.equal(deriveProjectionConfidence(need, uncertain), "partial");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## What changed

- Adds the Need-centered fulfillment ontology and durable Join, Witness, counter-witness, provenance-link, lifecycle, Soil, and projection types.
- Adds versioned deterministic canonicalization and SHA-256 content identity.
- Adds origin-specific fulfillment validation that permits unknown provenance without silently inventing it.
- Adds derived Need projection logic for status, remaining scope, `stillCalling`, and knowledge confidence.
- Adds draft/canonical fixture separation, a minting command, and a read-only fixture verifier.
- Mints the breakfast Need as explicit test data with a verified canonical hash.
- Ports the invariant checks to Node's native test runner.
- Freezes the fulfillment kernel contract in documentation.

## Why

This is the minimum lawful slice required for TranchNode to preserve a stable, attributable, disclosure-bounded claim that a scoped material response was reported to have crossed into reality, without confusing hashing with witness, witness with truth verification, or fulfillment with moral completion.

## Validation

Validated locally with Node 22:

```text
npm run check
fixtures/canonical/need_breakfast_001.json: verified sha256:fbf5737f8edb7f77637648b5b7810c73647ae46e62d0a8ffe7d225ec71a4c5ec
9 tests passed
```

## Boundaries

- The breakfast Need is a fixture, not a live household request.
- Canonical fixtures must be hash-complete.
- Derived projections never overwrite canonical records.
- Hashing supplies identity and tamper evidence; it does not prove the underlying event.