### PR TITLE
Prototype irreducible residual verifier v0.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
       - run: npm install
       - run: npm run check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm install
+      - run: npm run check

--- a/RESIDUAL_V0_1.md
+++ b/RESIDUAL_V0_1.md
@@ -1,0 +1,27 @@
+# Irreducible Residual Test v0.1
+
+## Acceptance claim
+
+The Irreducible Residual Test identifies declared historically material source features, verifies their treatment in a reconstruction, and prevents an altered output from entering the historical-reproduction path without explicit disclosure.
+
+## Constitutional rules
+
+1. Values are stored in addressed envelopes. Callers never supply the hash inside the value being hashed.
+2. JSON values are addressed using RFC 8785 JCS canonical serialization.
+3. Original media artifacts are hashed from their raw bytes. Format metadata is not substituted for the source bytes.
+4. Exact residuals bind to an immutable parent artifact and a format-specific locator.
+5. `preserved_exactly` is verifier-derived from matching extracted payload hashes.
+6. Historical status is categorical, not a similarity score.
+7. `violated` is inadmissible under every claim.
+8. Disclosed transformation or omission is lawful only outside the historical-reproduction path.
+
+## v0.1 scope
+
+The test fixture uses byte-backed stand-ins for manually declared audio slices. A production WAV extractor and immutable artifact-store adapter are deliberately deferred. The verifier boundary and acceptance behavior are executable now; media parsing is the next mechanical layer.
+
+## Commands
+
+```sh
+npm install
+npm run check
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tranchnode",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit && node --test --import tsx test/**/*.test.ts",
+    "test": "node --test --import tsx test/**/*.test.ts"
+  },
+  "dependencies": {
+    "canonicalize": "^2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/src/residual.ts
+++ b/src/residual.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
-import canonicalize from "canonicalize";
+import canonicalizeModule from "canonicalize";
+
+const canonicalize = canonicalizeModule.default ?? canonicalizeModule;
 
 export type Hash = `sha256:${string}`;
 export type Claim = "creative_realization" | "semantic_reconstruction" | "historical_reproduction";

--- a/src/residual.ts
+++ b/src/residual.ts
@@ -3,12 +3,20 @@ import canonicalize from "canonicalize";
 
 export type Hash = `sha256:${string}`;
 export type Claim = "creative_realization" | "semantic_reconstruction" | "historical_reproduction";
-export type HistoricalStatus = "exact" | "referential" | "altered_disclosed" | "not_historical" | "violated";
+export type HistoricalStatus = "EXACT_SOURCE_BYTES" | "EXACT_REQUIRED_RESIDUALS_REFERENCED" | "ALTERED_WITH_DISCLOSURE" | "NOT_HISTORICAL" | "VIOLATED";
 export type Outcome = "preserved_exactly" | "preserved_by_reference" | "transformed_with_disclosure" | "omitted_with_disclosure" | "violated";
 
 export interface Addressed<T> { hash: Hash; value: T }
 export interface ArtifactRef { hash: Hash; mediaType: string; byteLength: number }
-export interface SampleLocator { artifactHash: Hash; sampleRate: number; channels: number; sampleFormat: string; startSample: number; endSampleExclusive: number }
+export interface SampleLocator {
+  locatorVersion: "sample-v1";
+  sourceArtifact: Hash;
+  sampleRateHz: number;
+  channels: number;
+  sampleFormat: string;
+  startSample: number;
+  endSampleExclusive: number;
+}
 export interface ResidualBinding {
   id: string;
   source: SampleLocator;
@@ -57,6 +65,16 @@ export function addressJson<T>(value: T): Addressed<T> {
   return { hash: sha256(Buffer.from(encoded, "utf8")), value };
 }
 
+function sameLocator(a: SampleLocator, b: SampleLocator): boolean {
+  return a.locatorVersion === b.locatorVersion
+    && a.sourceArtifact === b.sourceArtifact
+    && a.sampleRateHz === b.sampleRateHz
+    && a.channels === b.channels
+    && a.sampleFormat === b.sampleFormat
+    && a.startSample === b.startSample
+    && a.endSampleExclusive === b.endSampleExclusive;
+}
+
 export function verifyReconstruction(field: Addressed<FieldNode>, receipt: ReconstructionReceipt): Verification {
   if (receipt.fieldHash !== field.hash) throw new Error("Receipt does not address this field");
   const evidence = new Map(receipt.evidence.map((item) => [item.residualId, item]));
@@ -66,8 +84,8 @@ export function verifyReconstruction(field: Addressed<FieldNode>, receipt: Recon
     if (proof.outputLocator && proof.extractedOutputHash === residual.extractedPayloadHash) {
       return { residualId: residual.id, outcome: "preserved_exactly", reason: "Verifier-extracted output payload matches source payload" };
     }
-    if (proof.sourceReference && proof.sourceReference.artifactHash === residual.source.artifactHash) {
-      return { residualId: residual.id, outcome: "preserved_by_reference", reason: "Immutable source artifact and locator retained by reference" };
+    if (proof.sourceReference && sameLocator(proof.sourceReference, residual.source)) {
+      return { residualId: residual.id, outcome: "preserved_by_reference", reason: "Exact immutable source artifact and locator retained by reference" };
     }
     if (proof.transformationReceiptHash) {
       return { residualId: residual.id, outcome: "transformed_with_disclosure", reason: "Transformation is explicitly receipted" };
@@ -85,11 +103,11 @@ export function verifyReconstruction(field: Addressed<FieldNode>, receipt: Recon
   const disclosedAlteration = outcomes.some((o) => o === "transformed_with_disclosure" || o === "omitted_with_disclosure");
 
   let historicalStatus: HistoricalStatus;
-  if (hasViolation) historicalStatus = "violated";
-  else if (allExact) historicalStatus = "exact";
-  else if (allHistorical) historicalStatus = "referential";
-  else if (disclosedAlteration) historicalStatus = "altered_disclosed";
-  else historicalStatus = "not_historical";
+  if (hasViolation) historicalStatus = "VIOLATED";
+  else if (allExact) historicalStatus = "EXACT_SOURCE_BYTES";
+  else if (allHistorical) historicalStatus = "EXACT_REQUIRED_RESIDUALS_REFERENCED";
+  else if (disclosedAlteration) historicalStatus = "ALTERED_WITH_DISCLOSURE";
+  else historicalStatus = "NOT_HISTORICAL";
 
   const admissible = !hasViolation && (receipt.claim !== "historical_reproduction" || allHistorical);
   return { historicalStatus, admissible, residualResults };

--- a/src/residual.ts
+++ b/src/residual.ts
@@ -1,0 +1,96 @@
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+
+export type Hash = `sha256:${string}`;
+export type Claim = "creative_realization" | "semantic_reconstruction" | "historical_reproduction";
+export type HistoricalStatus = "exact" | "referential" | "altered_disclosed" | "not_historical" | "violated";
+export type Outcome = "preserved_exactly" | "preserved_by_reference" | "transformed_with_disclosure" | "omitted_with_disclosure" | "violated";
+
+export interface Addressed<T> { hash: Hash; value: T }
+export interface ArtifactRef { hash: Hash; mediaType: string; byteLength: number }
+export interface SampleLocator { artifactHash: Hash; sampleRate: number; channels: number; sampleFormat: string; startSample: number; endSampleExclusive: number }
+export interface ResidualBinding {
+  id: string;
+  source: SampleLocator;
+  extractedPayloadHash: Hash;
+  preservationBasis: "historical" | "testimonial" | "identity" | "covenantal" | "forensic";
+  preservationMode: "exact_samples" | "cryptographic_commitment";
+}
+export interface FieldNode {
+  kind: "field";
+  fieldClass: "MATERIAL";
+  sources: ArtifactRef[];
+  residuals: ResidualBinding[];
+  authorityBoundary: { purpose: string; disclosureRequired: boolean };
+}
+export interface ResidualEvidence {
+  residualId: string;
+  outputLocator?: SampleLocator;
+  sourceReference?: SampleLocator;
+  extractedOutputHash?: Hash;
+  transformationReceiptHash?: Hash;
+  omissionReason?: string;
+}
+export interface ReconstructionReceipt {
+  kind: "reconstruction_receipt";
+  fieldHash: Hash;
+  outputArtifact: ArtifactRef;
+  claim: Claim;
+  decoder: { id: string; version: string };
+  perceptualScores: { phenomenal: number; semantic: number; structural: number };
+  evidence: ResidualEvidence[];
+}
+export interface VerifiedResidual { residualId: string; outcome: Outcome; reason: string }
+export interface Verification {
+  historicalStatus: HistoricalStatus;
+  admissible: boolean;
+  residualResults: VerifiedResidual[];
+}
+
+export function sha256(bytes: Uint8Array): Hash {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function addressJson<T>(value: T): Addressed<T> {
+  const encoded = canonicalize(value);
+  if (encoded === undefined) throw new Error("Value is not JCS-serializable");
+  return { hash: sha256(Buffer.from(encoded, "utf8")), value };
+}
+
+export function verifyReconstruction(field: Addressed<FieldNode>, receipt: ReconstructionReceipt): Verification {
+  if (receipt.fieldHash !== field.hash) throw new Error("Receipt does not address this field");
+  const evidence = new Map(receipt.evidence.map((item) => [item.residualId, item]));
+  const residualResults = field.value.residuals.map((residual): VerifiedResidual => {
+    const proof = evidence.get(residual.id);
+    if (!proof) return { residualId: residual.id, outcome: "violated", reason: "No evidence supplied" };
+    if (proof.outputLocator && proof.extractedOutputHash === residual.extractedPayloadHash) {
+      return { residualId: residual.id, outcome: "preserved_exactly", reason: "Verifier-extracted output payload matches source payload" };
+    }
+    if (proof.sourceReference && proof.sourceReference.artifactHash === residual.source.artifactHash) {
+      return { residualId: residual.id, outcome: "preserved_by_reference", reason: "Immutable source artifact and locator retained by reference" };
+    }
+    if (proof.transformationReceiptHash) {
+      return { residualId: residual.id, outcome: "transformed_with_disclosure", reason: "Transformation is explicitly receipted" };
+    }
+    if (proof.omissionReason) {
+      return { residualId: residual.id, outcome: "omitted_with_disclosure", reason: proof.omissionReason };
+    }
+    return { residualId: residual.id, outcome: "violated", reason: "Evidence absent, mismatched, or contradictory" };
+  });
+
+  const outcomes = residualResults.map((r) => r.outcome);
+  const hasViolation = outcomes.includes("violated");
+  const allExact = outcomes.every((o) => o === "preserved_exactly");
+  const allHistorical = outcomes.every((o) => o === "preserved_exactly" || o === "preserved_by_reference");
+  const disclosedAlteration = outcomes.some((o) => o === "transformed_with_disclosure" || o === "omitted_with_disclosure");
+
+  let historicalStatus: HistoricalStatus;
+  if (hasViolation) historicalStatus = "violated";
+  else if (allExact) historicalStatus = "exact";
+  else if (allHistorical) historicalStatus = "referential";
+  else if (disclosedAlteration) historicalStatus = "altered_disclosed";
+  else historicalStatus = "not_historical";
+
+  const admissible = !hasViolation && (receipt.claim !== "historical_reproduction" || allHistorical);
+  return { historicalStatus, admissible, residualResults };
+}

--- a/test/residual.test.ts
+++ b/test/residual.test.ts
@@ -20,8 +20,9 @@ const field = addressJson<FieldNode>({
   residuals: Object.entries(slices).map(([id, bytes], index) => ({
     id,
     source: {
-      artifactHash: sourceHash,
-      sampleRate: 48_000,
+      locatorVersion: "sample-v1",
+      sourceArtifact: sourceHash,
+      sampleRateHz: 48_000,
       channels: 1,
       sampleFormat: "s16le",
       startSample: index * 100,
@@ -45,9 +46,10 @@ function receipt(claim: ReconstructionReceipt["claim"], evidence: Reconstruction
   };
 }
 
-test("JCS addressing excludes any caller-supplied envelope hash", () => {
+test("JCS addressing excludes caller-supplied envelope hashes", () => {
   assert.match(field.hash, /^sha256:[0-9a-f]{64}$/);
   assert.equal("fieldHash" in field.value, false);
+  assert.equal("receiptHash" in field.value, false);
 });
 
 test("exactly preserved residuals admit historical reproduction", () => {
@@ -57,8 +59,15 @@ test("exactly preserved residuals admit historical reproduction", () => {
     extractedOutputHash: r.extractedPayloadHash
   }));
   const result = verifyReconstruction(field, receipt("historical_reproduction", evidence));
-  assert.equal(result.admissible, true);
-  assert.equal(result.historicalStatus, "exact");
+  assert.deepEqual(result, {
+    historicalStatus: "EXACT_SOURCE_BYTES",
+    admissible: true,
+    residualResults: field.value.residuals.map((r) => ({
+      residualId: r.id,
+      outcome: "preserved_exactly",
+      reason: "Verifier-extracted output payload matches source payload"
+    }))
+  });
 });
 
 test("disclosed omissions remain creative but cannot enter historical path", () => {
@@ -66,17 +75,21 @@ test("disclosed omissions remain creative but cannot enter historical path", () 
   const creative = verifyReconstruction(field, receipt("creative_realization", evidence));
   const historical = verifyReconstruction(field, receipt("historical_reproduction", evidence));
   assert.equal(creative.admissible, true);
-  assert.equal(creative.historicalStatus, "altered_disclosed");
+  assert.equal(creative.historicalStatus, "ALTERED_WITH_DISCLOSURE");
   assert.equal(historical.admissible, false);
+  assert.equal(historical.historicalStatus, "ALTERED_WITH_DISCLOSURE");
 });
 
-test("missing or contradictory evidence is a violation under every claim", () => {
+test("adversarial smoothing is VIOLATED and inadmissible under every claim", () => {
   const result = verifyReconstruction(field, receipt("semantic_reconstruction", [
     { residualId: "breath", omissionReason: "Removed" },
     { residualId: "correction", extractedOutputHash: sha256(Buffer.from("I said the door was locked.")) }
   ]));
   assert.equal(result.admissible, false);
-  assert.equal(result.historicalStatus, "violated");
-  assert.ok(result.residualResults.some((r) => r.residualId === "correction" && r.outcome === "violated"));
-  assert.ok(result.residualResults.some((r) => r.residualId === "click" && r.outcome === "violated"));
+  assert.equal(result.historicalStatus, "VIOLATED");
+  assert.deepEqual(result.residualResults.map(({ residualId, outcome }) => ({ residualId, outcome })), [
+    { residualId: "breath", outcome: "omitted_with_disclosure" },
+    { residualId: "correction", outcome: "violated" },
+    { residualId: "click", outcome: "violated" }
+  ]);
 });

--- a/test/residual.test.ts
+++ b/test/residual.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { addressJson, sha256, verifyReconstruction, type FieldNode, type ReconstructionReceipt } from "../src/residual.js";
+
+const sourceBytes = Buffer.from("[breath] I never said the door was locked— No. Wait. I did. [metallic click]");
+const sourceHash = sha256(sourceBytes);
+const artifact = { hash: sourceHash, mediaType: "audio/wav", byteLength: sourceBytes.length };
+
+const slices = {
+  breath: Buffer.from("[breath]"),
+  correction: Buffer.from("No. Wait. I did."),
+  click: Buffer.from("[metallic click]")
+};
+
+const field = addressJson<FieldNode>({
+  kind: "field",
+  fieldClass: "MATERIAL",
+  sources: [artifact],
+  authorityBoundary: { purpose: "irreducible-residual-test", disclosureRequired: true },
+  residuals: Object.entries(slices).map(([id, bytes], index) => ({
+    id,
+    source: {
+      artifactHash: sourceHash,
+      sampleRate: 48_000,
+      channels: 1,
+      sampleFormat: "s16le",
+      startSample: index * 100,
+      endSampleExclusive: index * 100 + bytes.length
+    },
+    extractedPayloadHash: sha256(bytes),
+    preservationBasis: id === "correction" ? "testimonial" : "historical",
+    preservationMode: "exact_samples"
+  }))
+});
+
+function receipt(claim: ReconstructionReceipt["claim"], evidence: ReconstructionReceipt["evidence"]): ReconstructionReceipt {
+  return {
+    kind: "reconstruction_receipt",
+    fieldHash: field.hash,
+    outputArtifact: { hash: sha256(Buffer.from("reconstruction")), mediaType: "audio/wav", byteLength: 14 },
+    claim,
+    decoder: { id: "fixture", version: "0.1" },
+    perceptualScores: { phenomenal: 0.88, semantic: 0.72, structural: 0.91 },
+    evidence
+  };
+}
+
+test("JCS addressing excludes any caller-supplied envelope hash", () => {
+  assert.match(field.hash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal("fieldHash" in field.value, false);
+});
+
+test("exactly preserved residuals admit historical reproduction", () => {
+  const evidence = field.value.residuals.map((r) => ({
+    residualId: r.id,
+    outputLocator: r.source,
+    extractedOutputHash: r.extractedPayloadHash
+  }));
+  const result = verifyReconstruction(field, receipt("historical_reproduction", evidence));
+  assert.equal(result.admissible, true);
+  assert.equal(result.historicalStatus, "exact");
+});
+
+test("disclosed omissions remain creative but cannot enter historical path", () => {
+  const evidence = field.value.residuals.map((r) => ({ residualId: r.id, omissionReason: "Smoothed creative alternate" }));
+  const creative = verifyReconstruction(field, receipt("creative_realization", evidence));
+  const historical = verifyReconstruction(field, receipt("historical_reproduction", evidence));
+  assert.equal(creative.admissible, true);
+  assert.equal(creative.historicalStatus, "altered_disclosed");
+  assert.equal(historical.admissible, false);
+});
+
+test("missing or contradictory evidence is a violation under every claim", () => {
+  const result = verifyReconstruction(field, receipt("semantic_reconstruction", [
+    { residualId: "breath", omissionReason: "Removed" },
+    { residualId: "correction", extractedOutputHash: sha256(Buffer.from("I said the door was locked.")) }
+  ]));
+  assert.equal(result.admissible, false);
+  assert.equal(result.historicalStatus, "violated");
+  assert.ok(result.residualResults.some((r) => r.residualId === "correction" && r.outcome === "violated"));
+  assert.ok(result.residualResults.some((r) => r.residualId === "click" && r.outcome === "violated"));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Constitutional claim

This slice identifies declared historically material source features, verifies their treatment in a reconstruction, and prevents altered output from entering the historical-reproduction path without explicit disclosure.

## Included

- addressed envelopes with SHA-256 identity
- RFC 8785 JCS canonical JSON addressing
- source-bound, versioned residual locators
- strict reconstruction claim taxonomy
- categorical historical status (`EXACT_SOURCE_BYTES`, `EXACT_REQUIRED_RESIDUALS_REFERENCED`, `ALTERED_WITH_DISCLOSURE`, `NOT_HISTORICAL`, `VIOLATED`)
- verifier-derived residual outcomes
- adversarial fixtures proving disclosed creative alteration remains usable while historical impersonation is rejected
- GitHub Actions check workflow

## Deliberate limits

- fixture slices are byte-backed stand-ins, not production WAV sample extraction
- no generator or nested projection machinery yet
- no decoder snapshotting yet

## Acceptance

`npm run check` type-checks and executes the four constitutional tests. The CI workflow now runs that command on pull requests and pushes to `main`. Keep the PR in draft until the first workflow run reports green.