### PR TITLE
Implement immutable filesystem artifact store

### DIFF
--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import {
+  constants as fsConstants,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { Hash } from "./residual.js";
+
+const SHA256_ADDRESS = /^sha256:([0-9a-f]{64})$/;
+
+export class ArtifactStoreError extends Error {
+  constructor(
+    public readonly code:
+      | "INVALID_ARTIFACT_ADDRESS"
+      | "PATH_ESCAPE"
+      | "ARTIFACT_CORRUPTION"
+      | "ARTIFACT_NOT_FOUND",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ArtifactStoreError";
+  }
+}
+
+export interface PutResult {
+  address: Hash;
+  created: boolean;
+  byteLength: number;
+}
+
+export function artifactAddress(bytes: Uint8Array): Hash {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function parseArtifactAddress(address: Hash | string): string {
+  const match = SHA256_ADDRESS.exec(address);
+  if (!match) {
+    throw new ArtifactStoreError(
+      "INVALID_ARTIFACT_ADDRESS",
+      "Artifact addresses must be lowercase sha256:<64 hex characters>",
+    );
+  }
+  return match[1];
+}
+
+export class FilesystemArtifactStore {
+  private readonly root: string;
+  private readonly objectsRoot: string;
+
+  constructor(root: string) {
+    if (!root || !isAbsolute(resolve(root))) {
+      throw new ArtifactStoreError("PATH_ESCAPE", "Artifact store root must resolve to an absolute path");
+    }
+    this.root = resolve(root);
+    this.objectsRoot = resolve(this.root, "objects", "sha256");
+  }
+
+  pathFor(address: Hash | string): string {
+    const digest = parseArtifactAddress(address);
+    const candidate = resolve(this.objectsRoot, digest.slice(0, 2), digest.slice(2, 4), digest);
+    this.assertInsideRoot(candidate);
+    return candidate;
+  }
+
+  async put(bytes: Uint8Array): Promise<PutResult> {
+    const payload = Buffer.from(bytes);
+    const address = artifactAddress(payload);
+    const destination = this.pathFor(address);
+    const directory = dirname(destination);
+    await mkdir(directory, { recursive: true });
+
+    const temporary = resolve(
+      directory,
+      `.${parseArtifactAddress(address)}.${process.pid}.${cryptoRandomSuffix()}.tmp`,
+    );
+    this.assertInsideRoot(temporary);
+
+    let file;
+    try {
+      file = await open(temporary, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY, 0o444);
+      await file.writeFile(payload);
+      await file.sync();
+      await file.close();
+      file = undefined;
+
+      try {
+        await rename(temporary, destination);
+        await this.syncDirectory(directory);
+        return { address, created: true, byteLength: payload.byteLength };
+      } catch (error) {
+        if (!isAlreadyExists(error)) throw error;
+      }
+    } finally {
+      if (file) await file.close().catch(() => undefined);
+      await rm(temporary, { force: true }).catch(() => undefined);
+    }
+
+    const existing = await this.readVerified(address);
+    if (!existing.equals(payload)) {
+      throw new ArtifactStoreError(
+        "ARTIFACT_CORRUPTION",
+        `Existing object at ${address} does not match supplied bytes`,
+      );
+    }
+    return { address, created: false, byteLength: payload.byteLength };
+  }
+
+  async get(address: Hash | string): Promise<Buffer> {
+    return this.readVerified(address);
+  }
+
+  private async readVerified(address: Hash | string): Promise<Buffer> {
+    const destination = this.pathFor(address);
+    try {
+      await this.assertExistingPathInsideRoot(destination);
+      const bytes = await readFile(destination);
+      const actual = artifactAddress(bytes);
+      if (actual !== address) {
+        throw new ArtifactStoreError(
+          "ARTIFACT_CORRUPTION",
+          `Stored bytes hash to ${actual}, not requested address ${address}`,
+        );
+      }
+      return bytes;
+    } catch (error) {
+      if (isNotFound(error)) {
+        throw new ArtifactStoreError("ARTIFACT_NOT_FOUND", `No artifact exists at ${address}`);
+      }
+      throw error;
+    }
+  }
+
+  private assertInsideRoot(candidate: string): void {
+    const rel = relative(this.root, candidate);
+    if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return;
+    throw new ArtifactStoreError("PATH_ESCAPE", "Resolved artifact path escapes the store root");
+  }
+
+  private async assertExistingPathInsideRoot(candidate: string): Promise<void> {
+    this.assertInsideRoot(candidate);
+    const [realRoot, realCandidate] = await Promise.all([realpath(this.root), realpath(candidate)]);
+    const rel = relative(realRoot, realCandidate);
+    if (rel.startsWith("..") || isAbsolute(rel)) {
+      throw new ArtifactStoreError("PATH_ESCAPE", "Artifact path resolves outside the store root");
+    }
+  }
+
+  private async syncDirectory(directory: string): Promise<void> {
+    try {
+      const handle = await open(directory, fsConstants.O_RDONLY);
+      try {
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+    } catch (error) {
+      if (!isUnsupportedDirectorySync(error)) throw error;
+    }
+  }
+}
+
+function cryptoRandomSuffix(): string {
+  return createHash("sha256")
+    .update(`${process.hrtime.bigint()}:${Math.random()}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return isNodeError(error) && (error.code === "EEXIST" || error.code === "ENOTEMPTY");
+}
+
+function isNotFound(error: unknown): boolean {
+  return isNodeError(error) && error.code === "ENOENT";
+}
+
+function isUnsupportedDirectorySync(error: unknown): boolean {
+  return isNodeError(error) && ["EINVAL", "ENOTSUP", "EISDIR", "EPERM"].includes(error.code ?? "");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -1,11 +1,11 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   constants as fsConstants,
+  link,
   mkdir,
   open,
   readFile,
   realpath,
-  rename,
   rm,
 } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
@@ -53,8 +53,8 @@ export class FilesystemArtifactStore {
   private readonly objectsRoot: string;
 
   constructor(root: string) {
-    if (!root || !isAbsolute(resolve(root))) {
-      throw new ArtifactStoreError("PATH_ESCAPE", "Artifact store root must resolve to an absolute path");
+    if (!root) {
+      throw new ArtifactStoreError("PATH_ESCAPE", "Artifact store root is required");
     }
     this.root = resolve(root);
     this.objectsRoot = resolve(this.root, "objects", "sha256");
@@ -73,10 +73,11 @@ export class FilesystemArtifactStore {
     const destination = this.pathFor(address);
     const directory = dirname(destination);
     await mkdir(directory, { recursive: true });
+    await this.assertDirectoryInsideRoot(directory);
 
     const temporary = resolve(
       directory,
-      `.${parseArtifactAddress(address)}.${process.pid}.${cryptoRandomSuffix()}.tmp`,
+      `.${parseArtifactAddress(address)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`,
     );
     this.assertInsideRoot(temporary);
 
@@ -89,7 +90,7 @@ export class FilesystemArtifactStore {
       file = undefined;
 
       try {
-        await rename(temporary, destination);
+        await link(temporary, destination);
         await this.syncDirectory(directory);
         return { address, created: true, byteLength: payload.byteLength };
       } catch (error) {
@@ -141,6 +142,15 @@ export class FilesystemArtifactStore {
     throw new ArtifactStoreError("PATH_ESCAPE", "Resolved artifact path escapes the store root");
   }
 
+  private async assertDirectoryInsideRoot(directory: string): Promise<void> {
+    this.assertInsideRoot(directory);
+    const [realRoot, realDirectory] = await Promise.all([realpath(this.root), realpath(directory)]);
+    const rel = relative(realRoot, realDirectory);
+    if (rel.startsWith("..") || isAbsolute(rel)) {
+      throw new ArtifactStoreError("PATH_ESCAPE", "Artifact directory resolves outside the store root");
+    }
+  }
+
   private async assertExistingPathInsideRoot(candidate: string): Promise<void> {
     this.assertInsideRoot(candidate);
     const [realRoot, realCandidate] = await Promise.all([realpath(this.root), realpath(candidate)]);
@@ -164,15 +174,8 @@ export class FilesystemArtifactStore {
   }
 }
 
-function cryptoRandomSuffix(): string {
-  return createHash("sha256")
-    .update(`${process.hrtime.bigint()}:${Math.random()}`)
-    .digest("hex")
-    .slice(0, 16);
-}
-
 function isAlreadyExists(error: unknown): boolean {
-  return isNodeError(error) && (error.code === "EEXIST" || error.code === "ENOTEMPTY");
+  return isNodeError(error) && error.code === "EEXIST";
 }
 
 function isNotFound(error: unknown): boolean {

--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -39,13 +39,14 @@ export function artifactAddress(bytes: Uint8Array): Hash {
 
 export function parseArtifactAddress(address: Hash | string): string {
   const match = SHA256_ADDRESS.exec(address);
-  if (!match) {
+  const digest = match?.[1];
+  if (!digest) {
     throw new ArtifactStoreError(
       "INVALID_ARTIFACT_ADDRESS",
       "Artifact addresses must be lowercase sha256:<64 hex characters>",
     );
   }
-  return match[1];
+  return digest;
 }
 
 export class FilesystemArtifactStore {

--- a/test/artifact-store.test.ts
+++ b/test/artifact-store.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -57,7 +57,9 @@ test("verified reads detect addressed-path corruption", async () => {
   await withStore(async (store) => {
     const bytes = Buffer.from("original", "utf8");
     const { address } = await store.put(bytes);
-    await writeFile(store.pathFor(address), Buffer.from("tampered", "utf8"));
+    const objectPath = store.pathFor(address);
+    await chmod(objectPath, 0o644);
+    await writeFile(objectPath, Buffer.from("tampered", "utf8"));
     await assert.rejects(
       store.get(address),
       (error: unknown) => error instanceof ArtifactStoreError && error.code === "ARTIFACT_CORRUPTION",

--- a/test/artifact-store.test.ts
+++ b/test/artifact-store.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import {
+  ArtifactStoreError,
+  FilesystemArtifactStore,
+  artifactAddress,
+  parseArtifactAddress,
+} from "../src/artifact-store.js";
+import { sha256 } from "../src/residual.js";
+
+async function withStore(run: (store: FilesystemArtifactStore, root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "tranchnode-artifacts-"));
+  try {
+    await run(new FilesystemArtifactStore(root), root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("put/get round trip uses the Project0-compatible raw-byte address", async () => {
+  await withStore(async (store) => {
+    const bytes = Buffer.from([0, 1, 2, 3, 255]);
+    const result = await store.put(bytes);
+    assert.equal(result.address, sha256(bytes));
+    assert.equal(result.address, artifactAddress(bytes));
+    assert.equal(result.created, true);
+    assert.deepEqual(await store.get(result.address), bytes);
+  });
+});
+
+test("duplicate writes are idempotent and concurrent identical writes converge", async () => {
+  await withStore(async (store) => {
+    const bytes = Buffer.from("same raw bytes", "utf8");
+    const results = await Promise.all(Array.from({ length: 12 }, () => store.put(bytes)));
+    assert.equal(new Set(results.map((result) => result.address)).size, 1);
+    assert.equal(results.filter((result) => result.created).length, 1);
+    assert.deepEqual(await store.get(results[0].address), bytes);
+  });
+});
+
+test("raw-byte identity is independent of filename, media type, and metadata", async () => {
+  await withStore(async (store) => {
+    const bytes = Buffer.from("artifact payload", "utf8");
+    const first = await store.put(bytes);
+    const second = await store.put(Buffer.from(bytes));
+    assert.equal(first.address, second.address);
+    assert.equal(second.created, false);
+  });
+});
+
+test("verified reads detect addressed-path corruption", async () => {
+  await withStore(async (store) => {
+    const bytes = Buffer.from("original", "utf8");
+    const { address } = await store.put(bytes);
+    await writeFile(store.pathFor(address), Buffer.from("tampered", "utf8"));
+    await assert.rejects(
+      store.get(address),
+      (error: unknown) => error instanceof ArtifactStoreError && error.code === "ARTIFACT_CORRUPTION",
+    );
+    await assert.rejects(
+      store.put(bytes),
+      (error: unknown) => error instanceof ArtifactStoreError && error.code === "ARTIFACT_CORRUPTION",
+    );
+  });
+});
+
+test("malformed addresses and traversal attempts cannot escape the root", async () => {
+  await withStore(async (store, root) => {
+    for (const address of [
+      "sha256:../outside",
+      "sha256:ABCDEF",
+      `sha256:${"0".repeat(63)}`,
+      `sha512:${"0".repeat(64)}`,
+    ]) {
+      assert.throws(
+        () => store.pathFor(address),
+        (error: unknown) => error instanceof ArtifactStoreError && error.code === "INVALID_ARTIFACT_ADDRESS",
+      );
+    }
+
+    const outside = await mkdtemp(join(tmpdir(), "tranchnode-outside-"));
+    try {
+      const bytes = Buffer.from("outside", "utf8");
+      const address = artifactAddress(bytes);
+      const digest = parseArtifactAddress(address);
+      const shard = join(root, "objects", "sha256", digest.slice(0, 2));
+      await mkdir(dirname(shard), { recursive: true });
+      await symlink(outside, shard, "dir");
+      const outsideObject = join(outside, digest.slice(2, 4), digest);
+      await mkdir(dirname(outsideObject), { recursive: true });
+      await writeFile(outsideObject, bytes);
+      await assert.rejects(
+        store.get(address),
+        (error: unknown) => error instanceof ArtifactStoreError && error.code === "PATH_ESCAPE",
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+test("object layout is deterministic", async () => {
+  await withStore(async (store) => {
+    const bytes = Buffer.from("layout", "utf8");
+    const address = artifactAddress(bytes);
+    const digest = parseArtifactAddress(address);
+    const { address: storedAddress } = await store.put(bytes);
+    assert.equal(storedAddress, address);
+    const stored = await readFile(store.pathFor(address));
+    assert.deepEqual(stored, bytes);
+    assert.match(store.pathFor(address), new RegExp(`objects[/\\\\]sha256[/\\\\]${digest.slice(0, 2)}[/\\\\]${digest.slice(2, 4)}[/\\\\]${digest}$`));
+  });
+});

--- a/test/artifact-store.test.ts
+++ b/test/artifact-store.test.ts
@@ -37,7 +37,9 @@ test("duplicate writes are idempotent and concurrent identical writes converge",
     const results = await Promise.all(Array.from({ length: 12 }, () => store.put(bytes)));
     assert.equal(new Set(results.map((result) => result.address)).size, 1);
     assert.equal(results.filter((result) => result.created).length, 1);
-    assert.deepEqual(await store.get(results[0].address), bytes);
+    const first = results[0];
+    assert.ok(first);
+    assert.deepEqual(await store.get(first.address), bytes);
   });
 });
 


### PR DESCRIPTION
Closes #6.

## What this slice establishes

- raw-byte SHA-256 artifact addresses compatible with the adopted Project0 mapping
- deterministic `objects/sha256/ab/cd/<digest>` layout
- atomic create-if-absent publication using an exclusive temporary file plus hard-link creation
- idempotent duplicate writes and safe convergence under concurrent identical writes
- fatal corruption detection for mismatching bytes at an addressed path
- verified reads that recompute the requested digest
- strict lowercase digest parsing and lexical path containment
- realpath checks preventing symlink traversal outside the store root
- file and containing-directory flushes where the platform permits
- no overwrite, update, delete, metadata, parsing, retention, or cloud behavior

## Acceptance coverage

- put/get round trip
- Project0-compatible address round trip
- duplicate idempotency
- concurrent convergence
- filename/media-type/metadata independence
- corruption detection on read and duplicate put
- malformed address rejection
- traversal and symlink escape rejection
- deterministic object layout

## Dependency note

PR #24 is merged and supplies the active identity floor. Issue #5 remains administratively open, but this implementation does not introduce a second addressing contract.