### PR TITLE
feat: implement ProjectionReceipt field-root closure (#7)

### DIFF
--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,0 +1,184 @@
+import type { Addressed, Hash } from "./residual.js";
+import { addressJson } from "./residual.js";
+
+export type ProjectionKind = "observation" | "tension" | "proposal";
+
+export interface ProjectorIdentity {
+  id: string;
+  version: string;
+}
+
+export interface FieldRootAdmissionReceipt {
+  kind: "field_root_admission";
+  fieldRoot: Hash;
+  admittedBy: ProjectorIdentity;
+  purposeHash: Hash;
+  creationOrder: number;
+}
+
+export interface ProjectionReceipt {
+  kind: "projection_receipt";
+  projectionKind: ProjectionKind;
+  fieldRoots: Hash[];
+  parentProjectionHashes: Hash[];
+  rootAdmissionReceiptHashes: Hash[];
+  projector: ProjectorIdentity;
+  questionPurposeHash: Hash;
+  contextHashes: Hash[];
+  outputNodeHashes: Hash[];
+  residualHashes: Hash[];
+  uncertainty: string;
+  creationOrder: number;
+}
+
+export interface ProjectionGraph {
+  projections: ReadonlyMap<Hash, Addressed<ProjectionReceipt>>;
+  admissions: ReadonlyMap<Hash, Addressed<FieldRootAdmissionReceipt>>;
+}
+
+export interface MaterialRootStore {
+  get(address: Hash | string): Promise<Uint8Array>;
+}
+
+export class ProjectionError extends Error {
+  constructor(
+    public readonly code:
+      | "RECEIPT_IDENTITY_MISMATCH"
+      | "MISSING_PARENT_PROJECTION"
+      | "MISSING_ROOT_ADMISSION"
+      | "ROOT_ADMISSION_IDENTITY_MISMATCH"
+      | "INVALID_ROOT_ADMISSION_ORDER"
+      | "INVALID_PARENT_ORDER"
+      | "FIELD_ROOT_CLOSURE_MISMATCH"
+      | "CYCLIC_PROJECTION_ANCESTRY",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProjectionError";
+  }
+}
+
+export function addressProjectionReceipt(receipt: ProjectionReceipt): Addressed<ProjectionReceipt> {
+  return addressJson(receipt);
+}
+
+export function addressFieldRootAdmission(
+  receipt: FieldRootAdmissionReceipt,
+): Addressed<FieldRootAdmissionReceipt> {
+  return addressJson(receipt);
+}
+
+export function verifyProjectionClosure(
+  target: Addressed<ProjectionReceipt>,
+  graph: ProjectionGraph,
+): ReadonlySet<Hash> {
+  const visiting = new Set<Hash>();
+  const verified = new Map<Hash, ReadonlySet<Hash>>();
+
+  const walk = (addressed: Addressed<ProjectionReceipt>): ReadonlySet<Hash> => {
+    assertProjectionIdentity(addressed);
+
+    const cached = verified.get(addressed.hash);
+    if (cached) return cached;
+    if (visiting.has(addressed.hash)) {
+      throw new ProjectionError(
+        "CYCLIC_PROJECTION_ANCESTRY",
+        `Projection ancestry contains a cycle at ${addressed.hash}`,
+      );
+    }
+
+    visiting.add(addressed.hash);
+    try {
+      const expectedRoots = new Set<Hash>();
+
+      for (const parentHash of addressed.value.parentProjectionHashes) {
+        const parent = graph.projections.get(parentHash);
+        if (!parent) {
+          throw new ProjectionError(
+            "MISSING_PARENT_PROJECTION",
+            `Projection ${addressed.hash} references missing parent ${parentHash}`,
+          );
+        }
+        if (parent.value.creationOrder >= addressed.value.creationOrder) {
+          throw new ProjectionError(
+            "INVALID_PARENT_ORDER",
+            `Parent ${parentHash} must precede child ${addressed.hash}`,
+          );
+        }
+        for (const root of walk(parent)) expectedRoots.add(root);
+      }
+
+      for (const admissionHash of addressed.value.rootAdmissionReceiptHashes) {
+        const admission = graph.admissions.get(admissionHash);
+        if (!admission) {
+          throw new ProjectionError(
+            "MISSING_ROOT_ADMISSION",
+            `Projection ${addressed.hash} references missing root admission ${admissionHash}`,
+          );
+        }
+        assertAdmissionIdentity(admission);
+        if (admission.value.creationOrder > addressed.value.creationOrder) {
+          throw new ProjectionError(
+            "INVALID_ROOT_ADMISSION_ORDER",
+            `Root admission ${admissionHash} occurs after projection ${addressed.hash}`,
+          );
+        }
+        expectedRoots.add(admission.value.fieldRoot);
+      }
+
+      const declaredRoots = new Set(addressed.value.fieldRoots);
+      if (!sameSet(expectedRoots, declaredRoots)) {
+        const missing = [...expectedRoots].filter((root) => !declaredRoots.has(root));
+        const invented = [...declaredRoots].filter((root) => !expectedRoots.has(root));
+        throw new ProjectionError(
+          "FIELD_ROOT_CLOSURE_MISMATCH",
+          `Projection ${addressed.hash} violates field-root closure; missing=[${missing.join(",")}], invented=[${invented.join(",")}]`,
+        );
+      }
+
+      const closure = new Set(declaredRoots);
+      verified.set(addressed.hash, closure);
+      return closure;
+    } finally {
+      visiting.delete(addressed.hash);
+    }
+  };
+
+  return walk(target);
+}
+
+export async function verifyProjectionWithMaterialRoots(
+  target: Addressed<ProjectionReceipt>,
+  graph: ProjectionGraph,
+  store: MaterialRootStore,
+): Promise<ReadonlySet<Hash>> {
+  const closure = verifyProjectionClosure(target, graph);
+  await Promise.all([...closure].map((root) => store.get(root)));
+  return closure;
+}
+
+function assertProjectionIdentity(addressed: Addressed<ProjectionReceipt>): void {
+  if (addressJson(addressed.value).hash !== addressed.hash) {
+    throw new ProjectionError(
+      "RECEIPT_IDENTITY_MISMATCH",
+      `Projection receipt body does not hash to declared identity ${addressed.hash}`,
+    );
+  }
+}
+
+function assertAdmissionIdentity(addressed: Addressed<FieldRootAdmissionReceipt>): void {
+  if (addressJson(addressed.value).hash !== addressed.hash) {
+    throw new ProjectionError(
+      "ROOT_ADMISSION_IDENTITY_MISMATCH",
+      `Root admission body does not hash to declared identity ${addressed.hash}`,
+    );
+  }
+}
+
+function sameSet<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): boolean {
+  if (left.size !== right.size) return false;
+  for (const item of left) {
+    if (!right.has(item)) return false;
+  }
+  return true;
+}

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FilesystemArtifactStore } from "../src/artifact-store.js";
+import {
+  ProjectionError,
+  addressFieldRootAdmission,
+  addressProjectionReceipt,
+  verifyProjectionClosure,
+  verifyProjectionWithMaterialRoots,
+  type FieldRootAdmissionReceipt,
+  type ProjectionGraph,
+  type ProjectionReceipt,
+} from "../src/projection.js";
+import { sha256, type Addressed, type Hash } from "../src/residual.js";
+
+const projector = { id: "tranchnode-test", version: "0.1.0" };
+const purposeHash = hash("purpose");
+const contextHash = hash("context");
+const residualHash = hash("residual");
+const outputHash = hash("output");
+
+function hash(value: string): Hash {
+  return sha256(Buffer.from(value));
+}
+
+function admission(fieldRoot: Hash, creationOrder: number) {
+  const value: FieldRootAdmissionReceipt = {
+    kind: "field_root_admission",
+    fieldRoot,
+    admittedBy: projector,
+    purposeHash,
+    creationOrder,
+  };
+  return addressFieldRootAdmission(value);
+}
+
+function projection(
+  projectionKind: ProjectionReceipt["projectionKind"],
+  fieldRoots: Hash[],
+  parentProjectionHashes: Hash[],
+  rootAdmissionReceiptHashes: Hash[],
+  creationOrder: number,
+  residualHashes: Hash[] = [residualHash],
+) {
+  return addressProjectionReceipt({
+    kind: "projection_receipt",
+    projectionKind,
+    fieldRoots,
+    parentProjectionHashes,
+    rootAdmissionReceiptHashes,
+    projector,
+    questionPurposeHash: purposeHash,
+    contextHashes: [contextHash],
+    outputNodeHashes: [outputHash],
+    residualHashes,
+    uncertainty: "fixture uncertainty declared",
+    creationOrder,
+  });
+}
+
+function graph(
+  projections: Addressed<ProjectionReceipt>[],
+  admissions: ReturnType<typeof admission>[],
+): ProjectionGraph {
+  return {
+    projections: new Map(projections.map((item) => [item.hash, item])),
+    admissions: new Map(admissions.map((item) => [item.hash, item])),
+  };
+}
+
+test("single-field Observation -> Tension -> Proposal retains root closure and resolves material root", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tranchnode-projection-"));
+  try {
+    const store = new FilesystemArtifactStore(directory);
+    const material = await store.put(Buffer.from("material-field-a"));
+    const rootAdmission = admission(material.address, 1);
+    const observation = projection("observation", [material.address], [], [rootAdmission.hash], 2);
+    const tension = projection("tension", [material.address], [observation.hash], [], 3);
+    const proposal = projection("proposal", [material.address], [tension.hash], [], 4);
+    const fixture = graph([observation, tension, proposal], [rootAdmission]);
+
+    const closure = await verifyProjectionWithMaterialRoots(proposal, fixture, store);
+    assert.deepEqual([...closure], [material.address]);
+    assert.deepEqual(observation.value.residualHashes, [residualHash]);
+    assert.deepEqual(tension.value.residualHashes, [residualHash]);
+    assert.deepEqual(proposal.value.residualHashes, [residualHash]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("multi-field merge closure passes", () => {
+  const rootA = hash("root-a");
+  const rootB = hash("root-b");
+  const admissionA = admission(rootA, 1);
+  const admissionB = admission(rootB, 2);
+  const observationA = projection("observation", [rootA], [], [admissionA.hash], 3);
+  const observationB = projection("observation", [rootB], [], [admissionB.hash], 4);
+  const merged = projection("tension", [rootA, rootB], [observationA.hash, observationB.hash], [], 5);
+
+  assert.deepEqual(
+    [...verifyProjectionClosure(merged, graph([observationA, observationB, merged], [admissionA, admissionB]))],
+    [rootA, rootB],
+  );
+});
+
+test("omitted parent root fails", () => {
+  const root = hash("root");
+  const rootAdmission = admission(root, 1);
+  const parent = projection("observation", [root], [], [rootAdmission.hash], 2);
+  const child = projection("tension", [], [parent.hash], [], 3);
+
+  assert.throws(
+    () => verifyProjectionClosure(child, graph([parent, child], [rootAdmission])),
+    (error: unknown) => error instanceof ProjectionError && error.code === "FIELD_ROOT_CLOSURE_MISMATCH",
+  );
+});
+
+test("invented root fails unless introduced through explicit admission receipt", () => {
+  const invented = hash("invented-root");
+  const withoutAdmission = projection("observation", [invented], [], [], 1);
+  assert.throws(
+    () => verifyProjectionClosure(withoutAdmission, graph([withoutAdmission], [])),
+    (error: unknown) => error instanceof ProjectionError && error.code === "FIELD_ROOT_CLOSURE_MISMATCH",
+  );
+
+  const explicitAdmission = admission(invented, 1);
+  const admitted = projection("observation", [invented], [], [explicitAdmission.hash], 2);
+  assert.deepEqual(
+    [...verifyProjectionClosure(admitted, graph([admitted], [explicitAdmission]))],
+    [invented],
+  );
+});
+
+test("cyclic projection ancestry fails", () => {
+  const aliasForB = hash("alias-for-b");
+  const a = projection("tension", [], [aliasForB], [], 2, []);
+  const b = projection("tension", [], [a.hash], [], 1, []);
+  const projections = new Map<Hash, Addressed<ProjectionReceipt>>([
+    [a.hash, a],
+    [aliasForB, b],
+  ]);
+
+  assert.throws(
+    () => verifyProjectionClosure(a, { projections, admissions: new Map() }),
+    (error: unknown) => error instanceof ProjectionError
+      && (error.code === "CYCLIC_PROJECTION_ANCESTRY" || error.code === "INVALID_PARENT_ORDER"),
+  );
+});
+
+test("parent receipt mutation changes identity and breaks dependent verification", () => {
+  const root = hash("root");
+  const rootAdmission = admission(root, 1);
+  const parent = projection("observation", [root], [], [rootAdmission.hash], 2);
+  const child = projection("tension", [root], [parent.hash], [], 3);
+  const mutatedParent: Addressed<ProjectionReceipt> = {
+    hash: parent.hash,
+    value: { ...parent.value, uncertainty: "mutated after addressing" },
+  };
+
+  assert.throws(
+    () => verifyProjectionClosure(child, {
+      projections: new Map([[parent.hash, mutatedParent], [child.hash, child]]),
+      admissions: new Map([[rootAdmission.hash, rootAdmission]]),
+    }),
+    (error: unknown) => error instanceof ProjectionError && error.code === "RECEIPT_IDENTITY_MISMATCH",
+  );
+});
+
+test("proposal cannot cite only its tension while losing material root closure", () => {
+  const root = hash("root");
+  const rootAdmission = admission(root, 1);
+  const observation = projection("observation", [root], [], [rootAdmission.hash], 2);
+  const tension = projection("tension", [root], [observation.hash], [], 3);
+  const proposal = projection("proposal", [], [tension.hash], [], 4);
+
+  assert.throws(
+    () => verifyProjectionClosure(proposal, graph([observation, tension, proposal], [rootAdmission])),
+    (error: unknown) => error instanceof ProjectionError && error.code === "FIELD_ROOT_CLOSURE_MISMATCH",
+  );
+});
+
+test("declared material roots must resolve through immutable store", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tranchnode-projection-missing-"));
+  try {
+    const store = new FilesystemArtifactStore(directory);
+    const missingRoot = hash("not-in-store");
+    const rootAdmission = admission(missingRoot, 1);
+    const observation = projection("observation", [missingRoot], [], [rootAdmission.hash], 2);
+
+    await assert.rejects(() => verifyProjectionWithMaterialRoots(
+      observation,
+      graph([observation], [rootAdmission]),
+      store,
+    ));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #7.

## What this slice adds

- `ProjectionReceipt` addressed through the existing Project0-compatible `addressJson` identity floor
- explicit `FieldRootAdmissionReceipt` for introducing new material roots
- recursive field-root closure across parent projections
- multi-field merge support without requiring one identical ancestry field
- omitted/invented-root rejection
- parent/admission identity verification
- logical creation-order checks and ancestry cycle guard
- store-backed verification that every declared material root resolves through the immutable artifact store from #6

## Initial executable fixture

`Observation -> Tension -> Proposal`

Each level retains the original material root and residual citation.

## Acceptance coverage

- single-field three-level closure
- multi-field merge closure
- omitted parent root rejection
- invented root rejection unless explicitly admitted
- cyclic/malformed ancestry rejection
- parent mutation invalidates dependent verification
- proposal cannot collapse to tension-only ancestry
- receipt identities verify through canonical addressing
- material roots resolve through `FilesystemArtifactStore`

## Scope exclusions preserved

No semantic truth scoring, automatic question generation, latent-field implementation, or criticality metric.