### PR TITLE
Implement real WAV PCM residual extraction

### DIFF
--- a/src/wav-pcm.ts
+++ b/src/wav-pcm.ts
@@ -1,0 +1,206 @@
+import type { Hash, ResidualBinding, SampleLocator } from "./residual.js";
+import { sha256 } from "./residual.js";
+
+export interface ArtifactReader {
+  get(address: Hash | string): Promise<Uint8Array>;
+}
+
+export interface ParsedPcmWav {
+  sampleRateHz: number;
+  channels: 1 | 2;
+  sampleFormat: "s16le";
+  frameCount: number;
+  dataOffset: number;
+  dataByteLength: number;
+}
+
+export interface ExtractedPcmResidual {
+  locator: SampleLocator;
+  payload: Buffer;
+  payloadHash: Hash;
+  frameCount: number;
+}
+
+export class WavPcmError extends Error {
+  constructor(
+    public readonly code:
+      | "MALFORMED_WAV"
+      | "UNSUPPORTED_WAV"
+      | "TRUNCATED_WAV"
+      | "LOCATOR_MISMATCH"
+      | "INVALID_SAMPLE_RANGE"
+      | "RESIDUAL_HASH_MISMATCH",
+    message: string,
+  ) {
+    super(message);
+    this.name = "WavPcmError";
+  }
+}
+
+export function parsePcmWav(input: Uint8Array): ParsedPcmWav {
+  const bytes = Buffer.from(input);
+  if (bytes.byteLength < 12) {
+    throw new WavPcmError("TRUNCATED_WAV", "WAV is shorter than the RIFF/WAVE header");
+  }
+  if (ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 12) !== "WAVE") {
+    throw new WavPcmError("MALFORMED_WAV", "Expected RIFF/WAVE container");
+  }
+
+  const riffEnd = bytes.readUInt32LE(4) + 8;
+  if (riffEnd > bytes.byteLength) {
+    throw new WavPcmError("TRUNCATED_WAV", "RIFF size extends beyond available bytes");
+  }
+  if (riffEnd !== bytes.byteLength) {
+    throw new WavPcmError("MALFORMED_WAV", "Trailing bytes exist outside the declared RIFF container");
+  }
+
+  let format: { sampleRateHz: number; channels: 1 | 2; blockAlign: number } | undefined;
+  let dataOffset: number | undefined;
+  let dataByteLength: number | undefined;
+  let offset = 12;
+
+  while (offset < riffEnd) {
+    if (offset + 8 > riffEnd) {
+      throw new WavPcmError("TRUNCATED_WAV", "Truncated WAV chunk header");
+    }
+
+    const chunkId = ascii(bytes, offset, offset + 4);
+    const chunkSize = bytes.readUInt32LE(offset + 4);
+    const payloadOffset = offset + 8;
+    const payloadEnd = payloadOffset + chunkSize;
+    const paddedEnd = payloadEnd + (chunkSize & 1);
+    if (payloadEnd > riffEnd || paddedEnd > riffEnd) {
+      throw new WavPcmError("TRUNCATED_WAV", `Chunk ${chunkId} extends beyond the RIFF container`);
+    }
+
+    if (chunkId === "fmt ") {
+      if (format) throw new WavPcmError("MALFORMED_WAV", "Multiple fmt chunks are not supported");
+      if (chunkSize < 16) throw new WavPcmError("TRUNCATED_WAV", "PCM fmt chunk is shorter than 16 bytes");
+
+      const audioFormat = bytes.readUInt16LE(payloadOffset);
+      const channels = bytes.readUInt16LE(payloadOffset + 2);
+      const sampleRateHz = bytes.readUInt32LE(payloadOffset + 4);
+      const byteRate = bytes.readUInt32LE(payloadOffset + 8);
+      const blockAlign = bytes.readUInt16LE(payloadOffset + 12);
+      const bitsPerSample = bytes.readUInt16LE(payloadOffset + 14);
+
+      if (audioFormat !== 1) throw new WavPcmError("UNSUPPORTED_WAV", `WAV format ${audioFormat} is not integer PCM`);
+      if (channels !== 1 && channels !== 2) {
+        throw new WavPcmError("UNSUPPORTED_WAV", `Only mono/stereo PCM is supported, got ${channels} channels`);
+      }
+      if (bitsPerSample !== 16) {
+        throw new WavPcmError("UNSUPPORTED_WAV", `Only 16-bit little-endian PCM is supported, got ${bitsPerSample}-bit`);
+      }
+      if (sampleRateHz === 0) throw new WavPcmError("MALFORMED_WAV", "Sample rate must be positive");
+
+      const expectedBlockAlign = channels * 2;
+      const expectedByteRate = sampleRateHz * expectedBlockAlign;
+      if (blockAlign !== expectedBlockAlign || byteRate !== expectedByteRate) {
+        throw new WavPcmError("MALFORMED_WAV", "PCM fmt byte-rate/block-align fields are inconsistent");
+      }
+      format = { sampleRateHz, channels, blockAlign };
+    } else if (chunkId === "data") {
+      if (dataOffset !== undefined) throw new WavPcmError("MALFORMED_WAV", "Multiple data chunks are not supported");
+      dataOffset = payloadOffset;
+      dataByteLength = chunkSize;
+    }
+
+    offset = paddedEnd;
+  }
+
+  if (!format) throw new WavPcmError("MALFORMED_WAV", "WAV has no fmt chunk");
+  if (dataOffset === undefined || dataByteLength === undefined) {
+    throw new WavPcmError("MALFORMED_WAV", "WAV has no data chunk");
+  }
+  if (dataByteLength % format.blockAlign !== 0) {
+    throw new WavPcmError("TRUNCATED_WAV", "PCM data chunk ends in a partial frame");
+  }
+
+  return {
+    sampleRateHz: format.sampleRateHz,
+    channels: format.channels,
+    sampleFormat: "s16le",
+    frameCount: dataByteLength / format.blockAlign,
+    dataOffset,
+    dataByteLength,
+  };
+}
+
+/**
+ * sample-v1 coordinates are PCM frame coordinates. A frame contains one sample
+ * per channel. Extracted payload bytes retain WAV PCM interleaving exactly:
+ * mono = [s0][s1]..., stereo = [L0][R0][L1][R1]..., each sample signed s16le.
+ */
+export function extractPcmSamples(input: Uint8Array, locator: SampleLocator): ExtractedPcmResidual {
+  const bytes = Buffer.from(input);
+  const wav = parsePcmWav(bytes);
+  assertLocatorMatches(wav, locator);
+
+  if (!Number.isSafeInteger(locator.startSample) || !Number.isSafeInteger(locator.endSampleExclusive)) {
+    throw new WavPcmError("INVALID_SAMPLE_RANGE", "Sample coordinates must be safe integers");
+  }
+  if (locator.startSample < 0 || locator.endSampleExclusive <= locator.startSample) {
+    throw new WavPcmError("INVALID_SAMPLE_RANGE", "Sample range must be non-empty and ordered");
+  }
+  if (locator.endSampleExclusive > wav.frameCount) {
+    throw new WavPcmError(
+      "INVALID_SAMPLE_RANGE",
+      `Sample range [${locator.startSample}, ${locator.endSampleExclusive}) exceeds ${wav.frameCount} PCM frames`,
+    );
+  }
+
+  const bytesPerFrame = wav.channels * 2;
+  const startByte = wav.dataOffset + locator.startSample * bytesPerFrame;
+  const endByte = wav.dataOffset + locator.endSampleExclusive * bytesPerFrame;
+  const payload = Buffer.from(bytes.subarray(startByte, endByte));
+  return {
+    locator,
+    payload,
+    payloadHash: sha256(payload),
+    frameCount: locator.endSampleExclusive - locator.startSample,
+  };
+}
+
+export async function extractPcmResidualFromStore(
+  store: ArtifactReader,
+  locator: SampleLocator,
+): Promise<ExtractedPcmResidual> {
+  const sourceBytes = await store.get(locator.sourceArtifact);
+  return extractPcmSamples(sourceBytes, locator);
+}
+
+export async function verifyExactPcmResidual(
+  store: ArtifactReader,
+  binding: ResidualBinding,
+): Promise<ExtractedPcmResidual> {
+  if (binding.preservationMode !== "exact_samples") {
+    throw new WavPcmError("LOCATOR_MISMATCH", "PCM extraction only verifies exact_samples residuals");
+  }
+  const extracted = await extractPcmResidualFromStore(store, binding.source);
+  if (extracted.payloadHash !== binding.extractedPayloadHash) {
+    throw new WavPcmError(
+      "RESIDUAL_HASH_MISMATCH",
+      `Extracted PCM hashes to ${extracted.payloadHash}, expected ${binding.extractedPayloadHash}`,
+    );
+  }
+  return extracted;
+}
+
+function assertLocatorMatches(wav: ParsedPcmWav, locator: SampleLocator): void {
+  if (locator.locatorVersion !== "sample-v1") {
+    throw new WavPcmError("LOCATOR_MISMATCH", `Unsupported locator version ${String(locator.locatorVersion)}`);
+  }
+  if (locator.sampleRateHz !== wav.sampleRateHz) {
+    throw new WavPcmError("LOCATOR_MISMATCH", `Locator sample rate ${locator.sampleRateHz} != WAV ${wav.sampleRateHz}`);
+  }
+  if (locator.channels !== wav.channels) {
+    throw new WavPcmError("LOCATOR_MISMATCH", `Locator channels ${locator.channels} != WAV ${wav.channels}`);
+  }
+  if (locator.sampleFormat !== wav.sampleFormat) {
+    throw new WavPcmError("LOCATOR_MISMATCH", `Locator format ${locator.sampleFormat} != WAV ${wav.sampleFormat}`);
+  }
+}
+
+function ascii(bytes: Buffer, start: number, end: number): string {
+  return bytes.toString("ascii", start, end);
+}

--- a/test/wav-pcm.test.ts
+++ b/test/wav-pcm.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { FilesystemArtifactStore } from "../src/artifact-store.js";
+import {
+  addressFieldRootAdmission,
+  addressProjectionReceipt,
+  verifyProjectionWithMaterialRoots,
+  type ProjectionGraph,
+} from "../src/projection.js";
+import { addressJson, sha256, type ResidualBinding, type SampleLocator } from "../src/residual.js";
+import {
+  WavPcmError,
+  extractPcmResidualFromStore,
+  extractPcmSamples,
+  parsePcmWav,
+  verifyExactPcmResidual,
+} from "../src/wav-pcm.js";
+
+function pcm16(samples: number[]): Buffer {
+  const bytes = Buffer.alloc(samples.length * 2);
+  samples.forEach((sample, index) => bytes.writeInt16LE(sample, index * 2));
+  return bytes;
+}
+
+function chunk(id: string, payload: Uint8Array): Buffer {
+  const pad = payload.byteLength & 1;
+  const out = Buffer.alloc(8 + payload.byteLength + pad);
+  out.write(id, 0, 4, "ascii");
+  out.writeUInt32LE(payload.byteLength, 4);
+  Buffer.from(payload).copy(out, 8);
+  return out;
+}
+
+function wav16(
+  samples: number[],
+  options: { sampleRateHz?: number; channels?: 1 | 2; metadata?: Buffer } = {},
+): Buffer {
+  const sampleRateHz = options.sampleRateHz ?? 48_000;
+  const channels = options.channels ?? 1;
+  assert.equal(samples.length % channels, 0, "samples must contain complete interleaved frames");
+
+  const fmt = Buffer.alloc(16);
+  fmt.writeUInt16LE(1, 0);
+  fmt.writeUInt16LE(channels, 2);
+  fmt.writeUInt32LE(sampleRateHz, 4);
+  fmt.writeUInt32LE(sampleRateHz * channels * 2, 8);
+  fmt.writeUInt16LE(channels * 2, 12);
+  fmt.writeUInt16LE(16, 14);
+
+  const chunks = [chunk("fmt ", fmt)];
+  if (options.metadata) chunks.push(chunk("JUNK", options.metadata));
+  chunks.push(chunk("data", pcm16(samples)));
+  const waveBody = Buffer.concat([Buffer.from("WAVE", "ascii"), ...chunks]);
+  const out = Buffer.alloc(8 + waveBody.byteLength);
+  out.write("RIFF", 0, 4, "ascii");
+  out.writeUInt32LE(waveBody.byteLength, 4);
+  waveBody.copy(out, 8);
+  return out;
+}
+
+async function storeFor(t: TestContext): Promise<FilesystemArtifactStore> {
+  const root = await mkdtemp(join(tmpdir(), "tranchnode-wav-pcm-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return new FilesystemArtifactStore(root);
+}
+
+function locator(
+  sourceArtifact: SampleLocator["sourceArtifact"],
+  overrides: Partial<SampleLocator> = {},
+): SampleLocator {
+  return {
+    locatorVersion: "sample-v1",
+    sourceArtifact,
+    sampleRateHz: 48_000,
+    channels: 1,
+    sampleFormat: "s16le",
+    startSample: 1,
+    endSampleExclusive: 3,
+    ...overrides,
+  };
+}
+
+function binding(source: SampleLocator, payload: Uint8Array): ResidualBinding {
+  return {
+    id: "declared-source-slice",
+    source,
+    extractedPayloadHash: sha256(payload),
+    preservationBasis: "historical",
+    preservationMode: "exact_samples",
+  };
+}
+
+test("parses mono/stereo 16-bit PCM and documents frame-interleaved extraction", () => {
+  const mono = wav16([10, 20, 30, 40]);
+  assert.deepEqual(parsePcmWav(mono), {
+    sampleRateHz: 48_000,
+    channels: 1,
+    sampleFormat: "s16le",
+    frameCount: 4,
+    dataOffset: 44,
+    dataByteLength: 8,
+  });
+
+  const stereo = wav16([1, 2, 3, 4, 5, 6], { channels: 2 });
+  const extracted = extractPcmSamples(
+    stereo,
+    locator(sha256(stereo), { channels: 2, startSample: 1, endSampleExclusive: 3 }),
+  );
+  assert.deepEqual([...extracted.payload], [...pcm16([3, 4, 5, 6])]);
+  assert.equal(extracted.frameCount, 2);
+});
+
+test("declared source slice verifies through the immutable artifact store", async (t) => {
+  const store = await storeFor(t);
+  const source = wav16([100, -100, 200, -200]);
+  const stored = await store.put(source);
+  const sourceLocator = locator(stored.address);
+  const expected = pcm16([-100, 200]);
+
+  const verified = await verifyExactPcmResidual(store, binding(sourceLocator, expected));
+  assert.equal(verified.payloadHash, sha256(expected));
+  assert.deepEqual(verified.payload, expected);
+});
+
+test("resampled or locator-incompatible WAVs fail closed", async (t) => {
+  const store = await storeFor(t);
+  const resampled = wav16([100, -100, 200, -200], { sampleRateHz: 44_100 });
+  const stored = await store.put(resampled);
+
+  await assert.rejects(
+    () => extractPcmResidualFromStore(store, locator(stored.address)),
+    (error: unknown) => error instanceof WavPcmError && error.code === "LOCATOR_MISMATCH",
+  );
+
+  assert.throws(
+    () => extractPcmSamples(wav16([1, 2, 3, 4], { channels: 2 }), locator(sha256(Buffer.alloc(0)))),
+    (error: unknown) => error instanceof WavPcmError && error.code === "LOCATOR_MISMATCH",
+  );
+
+  assert.throws(
+    () => extractPcmSamples(wav16([1, 2, 3, 4]), locator(sha256(Buffer.alloc(0)), { sampleFormat: "s24le" })),
+    (error: unknown) => error instanceof WavPcmError && error.code === "LOCATOR_MISMATCH",
+  );
+});
+
+test("off-by-one coordinates do not satisfy an exact residual commitment", async (t) => {
+  const store = await storeFor(t);
+  const source = wav16([10, 20, 30, 40, 50]);
+  const stored = await store.put(source);
+  const expected = pcm16([20, 30]);
+  const exact = binding(locator(stored.address), expected);
+
+  await verifyExactPcmResidual(store, exact);
+  await assert.rejects(
+    () => verifyExactPcmResidual(store, { ...exact, source: { ...exact.source, startSample: 0 } }),
+    (error: unknown) => error instanceof WavPcmError && error.code === "RESIDUAL_HASH_MISMATCH",
+  );
+  await assert.rejects(
+    () => verifyExactPcmResidual(store, { ...exact, source: { ...exact.source, endSampleExclusive: 4 } }),
+    (error: unknown) => error instanceof WavPcmError && error.code === "RESIDUAL_HASH_MISMATCH",
+  );
+});
+
+test("truncated data chunks and malformed sample ranges fail closed", () => {
+  const valid = wav16([1, 2, 3, 4]);
+  const truncated = valid.subarray(0, valid.byteLength - 1);
+  assert.throws(
+    () => parsePcmWav(truncated),
+    (error: unknown) => error instanceof WavPcmError && error.code === "TRUNCATED_WAV",
+  );
+
+  assert.throws(
+    () => extractPcmSamples(valid, locator(sha256(valid), { startSample: 3, endSampleExclusive: 5 })),
+    (error: unknown) => error instanceof WavPcmError && error.code === "INVALID_SAMPLE_RANGE",
+  );
+});
+
+test("container metadata changes full identity without changing exact PCM identity", async (t) => {
+  const store = await storeFor(t);
+  const plain = wav16([7, 8, 9, 10]);
+  const annotated = wav16([7, 8, 9, 10], { metadata: Buffer.from("same-pcm,different-container") });
+  const plainStored = await store.put(plain);
+  const annotatedStored = await store.put(annotated);
+  assert.notEqual(plainStored.address, annotatedStored.address);
+
+  const plainPcm = await extractPcmResidualFromStore(store, locator(plainStored.address));
+  const annotatedPcm = await extractPcmResidualFromStore(store, locator(annotatedStored.address));
+  assert.equal(plainPcm.payloadHash, annotatedPcm.payloadHash);
+});
+
+test("a residual citation can retain #7 field-root closure to the stored WAV", async (t) => {
+  const store = await storeFor(t);
+  const source = wav16([11, 22, 33, 44]);
+  const stored = await store.put(source);
+  const sourceLocator = locator(stored.address);
+  const residual = binding(sourceLocator, pcm16([22, 33]));
+  await verifyExactPcmResidual(store, residual);
+
+  const admission = addressFieldRootAdmission({
+    kind: "field_root_admission",
+    fieldRoot: stored.address,
+    admittedBy: { id: "wav-pcm-fixture", version: "1" },
+    purposeHash: sha256(Buffer.from("verify material residual")),
+    creationOrder: 0,
+  });
+  const projection = addressProjectionReceipt({
+    kind: "projection_receipt",
+    projectionKind: "observation",
+    fieldRoots: [stored.address],
+    parentProjectionHashes: [],
+    rootAdmissionReceiptHashes: [admission.hash],
+    projector: { id: "wav-pcm-fixture", version: "1" },
+    questionPurposeHash: sha256(Buffer.from("what is materially present")),
+    contextHashes: [],
+    outputNodeHashes: [],
+    residualHashes: [addressJson(residual).hash],
+    uncertainty: "none for exact PCM bytes",
+    creationOrder: 1,
+  });
+  const graph: ProjectionGraph = {
+    projections: new Map([[projection.hash, projection]]),
+    admissions: new Map([[admission.hash, admission]]),
+  };
+
+  assert.deepEqual([...await verifyProjectionWithMaterialRoots(projection, graph, store)], [stored.address]);
+});


### PR DESCRIPTION
Closes #8.

## What changed
- add strict RIFF/WAVE parsing for integer PCM
- support mono/stereo 16-bit little-endian PCM
- define `sample-v1` coordinates as PCM frame coordinates while preserving channel interleaving in extracted payload bytes
- read source artifacts through the immutable artifact store
- verify exact extracted PCM hashes against manual residual declarations
- fail closed on malformed/truncated containers, unsupported formats, locator mismatches, invalid ranges, and hash mismatches
- prove container metadata changes can alter full artifact identity while preserving exact PCM residual identity
- prove residual citations can retain #7 field-root closure back to the stored WAV

## Boundary
No MP3/AAC/FLAC, compressed WAV, resampling tolerance, perceptual matching, or automatic residual discovery. Residual declaration remains manual.

## Validation
Added focused `wav-pcm` tests covering exact-store verification, interleaving, sample-rate/channel/format mismatch, off-by-one coordinates, truncation, metadata/container identity, and projection root closure.