### PR TITLE
Reconcile fulfillment kernel with landed substrate

### DIFF
--- a/docs/FULFILLMENT_KERNEL.md
+++ b/docs/FULFILLMENT_KERNEL.md
@@ -1,0 +1,40 @@
+# Fulfillment kernel reconciliation
+
+Issue #9 is the Layer 5 compatibility pass over the now-landed substrate. Fulfillment remains Need-centered domain law; it does not own identity, material storage, projection closure, or WAV residual extraction.
+
+## Canonical boundary
+
+Canonical fulfillment bodies do **not** store their own hash. They are addressed externally through the repository's shared `addressJson` path, which carries the Project0-compatible JCS and SHA-256 rules. Draft fixtures may be incomplete; canonical fixtures must be complete canonical bodies, but neither may embed self-referential identity.
+
+## Substrate composition
+
+`verifyFulfillmentAgainstSubstrate` composes the existing floor rather than reproducing it:
+
+1. address the Need body through shared canonical identity and require `needSnapshotHash` to match it;
+2. read every material artifact reference through the immutable artifact store, which verifies bytes against the requested address;
+3. when a fulfillment references a projection receipt, verify the projection's ancestry and field-root closure and require every material field root to exist in the store;
+4. when a fulfillment references exact WAV residual evidence, verify the named residual bindings through the real PCM extraction path;
+5. only after those checks, externally address the fulfillment receipt itself.
+
+The fulfillment layer never redefines source identity, artifact identity, projection ancestry, field-root admission, sample coordinates, PCM parsing, or residual hashing.
+
+## Domain law retained
+
+- Need remains the center of the workflow.
+- A fulfillment receipt records a scoped reported crossing; it does not declare moral completion.
+- Witness is observation, not objective certification.
+- Unknown provenance remains unknown and cannot acquire joins, offers, or external provenance by implication.
+- Disclosure policy is explicit and remains distinct from generic claims of consent.
+- Need status, remaining scope, and `stillCalling` are derived projections and never canonical Need fields.
+- The child may remain telos without becoming telemetry.
+
+## Fixture discipline
+
+- `fixtures/drafts/fulfillment/` contains incomplete working bodies.
+- `fixtures/canonical/fulfillment/` contains complete canonical bodies suitable for external addressing.
+- Canonical fixtures must never contain `canonicalHash` or any equivalent self-identity field.
+- Tests exercise the canonical fixture against shared identity, immutable material storage, field-root closure, and real WAV PCM residual verification.
+
+## Non-goals
+
+This slice does not expand TranchNode's philosophy, add a second canonicalizer, create a fulfillment-local artifact store, reinterpret projection semantics, or introduce new residual formats. Those would violate the separation #9 exists to restore.

--- a/fixtures/canonical/fulfillment/need_breakfast_001.json
+++ b/fixtures/canonical/fulfillment/need_breakfast_001.json
@@ -1,0 +1,27 @@
+{
+  "type": "NEED_DECLARED",
+  "version": 1,
+  "id": "fixture_need_breakfast_001",
+  "createdAt": "2026-07-31T00:00:00Z",
+  "createdBy": "actor_fixture",
+  "visibility": "circle",
+  "summary": "Breakfast capacity requested for a local morning meal table.",
+  "kind": "meal",
+  "requestedQuantity": {
+    "value": 33,
+    "unit": "meal"
+  },
+  "disclosurePolicy": {
+    "audience": "circle",
+    "permittedFields": {
+      "summary": true,
+      "quantity": true,
+      "coarseTime": true,
+      "coarsePlace": true,
+      "exactPlace": false,
+      "participantIdentity": false,
+      "artifacts": false
+    },
+    "basis": "aggregate_only"
+  }
+}

--- a/fixtures/drafts/fulfillment/need_breakfast_001.draft.json
+++ b/fixtures/drafts/fulfillment/need_breakfast_001.draft.json
@@ -1,0 +1,11 @@
+{
+  "type": "NEED_DECLARED",
+  "version": 1,
+  "id": "fixture_need_breakfast_001",
+  "summary": "Breakfast capacity requested for a local morning meal table.",
+  "kind": "meal",
+  "requestedQuantity": {
+    "value": 33,
+    "unit": "meal"
+  }
+}

--- a/src/fulfillment-substrate.ts
+++ b/src/fulfillment-substrate.ts
@@ -1,0 +1,154 @@
+import type { Addressed, Hash, ResidualBinding } from "./residual.js";
+import { addressJson } from "./residual.js";
+import type { MaterialRootStore, ProjectionGraph, ProjectionReceipt } from "./projection.js";
+import { verifyProjectionWithMaterialRoots } from "./projection.js";
+import type { ArtifactReader } from "./wav-pcm.js";
+import { verifyExactPcmResidual } from "./wav-pcm.js";
+import type { FulfillmentRecorded, NeedDeclared } from "./fulfillment.js";
+import { validateFulfillmentReceipt, validateNeedDeclared } from "./fulfillment.js";
+
+export interface FulfillmentStore extends MaterialRootStore, ArtifactReader {}
+
+export interface FulfillmentProjectionEvidence {
+  target: Addressed<ProjectionReceipt>;
+  graph: ProjectionGraph;
+}
+
+export interface FulfillmentEvidence {
+  projection?: FulfillmentProjectionEvidence;
+  residualBindings?: ResidualBinding[];
+}
+
+export interface FulfillmentVerification {
+  need: Addressed<NeedDeclared>;
+  fulfillment: Addressed<FulfillmentRecorded>;
+  materialArtifactHashes: readonly Hash[];
+  fieldRoots: readonly Hash[];
+  residualIds: readonly string[];
+}
+
+export class FulfillmentKernelError extends Error {
+  constructor(
+    public readonly code:
+      | "NEED_ID_MISMATCH"
+      | "NEED_SNAPSHOT_MISMATCH"
+      | "PROJECTION_EVIDENCE_MISSING"
+      | "PROJECTION_REFERENCE_MISMATCH"
+      | "RESIDUAL_EVIDENCE_MISSING"
+      | "RESIDUAL_REFERENCE_MISMATCH"
+      | "DUPLICATE_RESIDUAL_ID",
+    message: string,
+  ) {
+    super(message);
+    this.name = "FulfillmentKernelError";
+  }
+}
+
+/**
+ * Reconciles fulfillment-specific claims against the shared substrate.
+ *
+ * This function does not redefine identity, storage, projection closure, or
+ * residual extraction. It composes those already-landed mechanics and returns
+ * the externally addressed canonical fulfillment body after verification.
+ */
+export async function verifyFulfillmentAgainstSubstrate(
+  need: NeedDeclared,
+  receipt: FulfillmentRecorded,
+  evidence: FulfillmentEvidence,
+  store: FulfillmentStore,
+): Promise<FulfillmentVerification> {
+  validateNeedDeclared(need as unknown as Record<string, unknown>);
+  validateFulfillmentReceipt(receipt);
+
+  if (receipt.needId !== need.id) {
+    throw new FulfillmentKernelError(
+      "NEED_ID_MISMATCH",
+      `Fulfillment ${receipt.id} names need ${receipt.needId}, not ${need.id}`,
+    );
+  }
+
+  const addressedNeed = addressJson(need);
+  if (receipt.needSnapshotHash !== addressedNeed.hash) {
+    throw new FulfillmentKernelError(
+      "NEED_SNAPSHOT_MISMATCH",
+      `Fulfillment ${receipt.id} references ${receipt.needSnapshotHash}, expected ${addressedNeed.hash}`,
+    );
+  }
+
+  const materialArtifactHashes = receipt.materialArtifactHashes ?? [];
+  await Promise.all(materialArtifactHashes.map((hash) => store.get(hash)));
+
+  let fieldRoots: readonly Hash[] = [];
+  if (receipt.projectionReceiptHash) {
+    if (!evidence.projection) {
+      throw new FulfillmentKernelError(
+        "PROJECTION_EVIDENCE_MISSING",
+        `Fulfillment ${receipt.id} references projection ${receipt.projectionReceiptHash} without its verification graph`,
+      );
+    }
+    if (evidence.projection.target.hash !== receipt.projectionReceiptHash) {
+      throw new FulfillmentKernelError(
+        "PROJECTION_REFERENCE_MISMATCH",
+        `Fulfillment ${receipt.id} references ${receipt.projectionReceiptHash}, evidence supplied ${evidence.projection.target.hash}`,
+      );
+    }
+    fieldRoots = [...await verifyProjectionWithMaterialRoots(
+      evidence.projection.target,
+      evidence.projection.graph,
+      store,
+    )];
+  } else if (evidence.projection) {
+    throw new FulfillmentKernelError(
+      "PROJECTION_REFERENCE_MISMATCH",
+      `Projection evidence supplied for fulfillment ${receipt.id}, but the canonical receipt does not reference it`,
+    );
+  }
+
+  const referencedResidualIds = receipt.residualIds ?? [];
+  assertUniqueResidualIds(referencedResidualIds);
+  const suppliedResiduals = evidence.residualBindings ?? [];
+  assertUniqueResidualIds(suppliedResiduals.map((binding) => binding.id));
+
+  if (referencedResidualIds.length > 0 && suppliedResiduals.length === 0) {
+    throw new FulfillmentKernelError(
+      "RESIDUAL_EVIDENCE_MISSING",
+      `Fulfillment ${receipt.id} references residual evidence without supplying bindings`,
+    );
+  }
+
+  const suppliedById = new Map(suppliedResiduals.map((binding) => [binding.id, binding]));
+  if (
+    suppliedResiduals.length !== referencedResidualIds.length ||
+    referencedResidualIds.some((id) => !suppliedById.has(id))
+  ) {
+    throw new FulfillmentKernelError(
+      "RESIDUAL_REFERENCE_MISMATCH",
+      `Fulfillment ${receipt.id} residual references do not match supplied residual bindings`,
+    );
+  }
+
+  for (const id of referencedResidualIds) {
+    const binding = suppliedById.get(id);
+    if (!binding) {
+      throw new FulfillmentKernelError(
+        "RESIDUAL_REFERENCE_MISMATCH",
+        `Residual ${id} was referenced but not supplied`,
+      );
+    }
+    await verifyExactPcmResidual(store, binding);
+  }
+
+  return {
+    need: addressedNeed,
+    fulfillment: addressJson(receipt),
+    materialArtifactHashes,
+    fieldRoots,
+    residualIds: referencedResidualIds,
+  };
+}
+
+function assertUniqueResidualIds(ids: readonly string[]): void {
+  if (new Set(ids).size !== ids.length) {
+    throw new FulfillmentKernelError("DUPLICATE_RESIDUAL_ID", "Residual ids must be unique");
+  }
+}

--- a/src/fulfillment.ts
+++ b/src/fulfillment.ts
@@ -1,0 +1,241 @@
+import type { Hash } from "./residual.js";
+
+export type EntityId = string;
+export type ISO8601 = string;
+
+export type Quantity = { value: number; unit: string };
+export type Visibility = "private" | "participants" | "circle" | "public";
+export type FulfillmentKind =
+  | "meal"
+  | "grocery"
+  | "childcare"
+  | "tutoring"
+  | "repair"
+  | "transport"
+  | "oral_history"
+  | "planting"
+  | "other";
+export type FulfillmentOutcome = "attempted" | "partial" | "scoped_complete" | "scope_uncertain";
+export type FulfillmentOrigin = "joined_offer" | "direct_response" | "external" | "unknown";
+
+export interface DisclosurePolicy {
+  audience: Visibility;
+  permittedFields: {
+    summary: boolean;
+    quantity: boolean;
+    coarseTime: boolean;
+    coarsePlace: boolean;
+    exactPlace: boolean;
+    participantIdentity: boolean;
+    artifacts: boolean;
+  };
+  basis:
+    | "participant_authorized"
+    | "recorder_only"
+    | "aggregate_only"
+    | "public_event"
+    | "withheld";
+}
+
+export interface ExternalProvenance {
+  system?: string;
+  sourceRef: string;
+  sourceHash?: Hash;
+}
+
+/**
+ * Canonical fulfillment bodies deliberately do not contain their own identity.
+ * Address them through the shared Project0-compatible addressJson path.
+ */
+export interface NeedDeclared {
+  id: EntityId;
+  type: "NEED_DECLARED";
+  version: 1;
+  createdAt: ISO8601;
+  createdBy: EntityId;
+  visibility: Visibility;
+  summary: string;
+  kind: FulfillmentKind;
+  requestedQuantity?: Quantity;
+  disclosurePolicy: DisclosurePolicy;
+}
+
+export interface FulfillmentRecorded {
+  id: EntityId;
+  type: "FULFILLMENT_RECORDED";
+  version: 1;
+  needId: EntityId;
+  needSnapshotHash: Hash;
+  offerId?: EntityId;
+  offerIds?: EntityId[];
+  joinId?: EntityId;
+  origin: FulfillmentOrigin;
+  externalProvenance?: ExternalProvenance;
+  outcome: FulfillmentOutcome;
+  occurredAt: ISO8601;
+  recordedAt: ISO8601;
+  recordedBy: EntityId;
+  fulfillment: {
+    kind: FulfillmentKind;
+    summary: string;
+    quantity?: Quantity;
+  };
+  visibility: Visibility;
+  disclosurePolicy: DisclosurePolicy;
+  materialArtifactHashes?: Hash[];
+  projectionReceiptHash?: Hash;
+  residualIds?: string[];
+}
+
+export interface WitnessRecorded {
+  id: EntityId;
+  type: "WITNESS_RECORDED";
+  version: 1;
+  subjectId: EntityId;
+  mode: "self_attested" | "participant" | "third_party" | "artifact";
+  statement?: string;
+  artifactHashes?: Hash[];
+  witnessedAt?: ISO8601;
+  recordedAt: ISO8601;
+  recordedBy: EntityId;
+  visibility: Visibility;
+  disclosurePolicy?: DisclosurePolicy;
+}
+
+export interface NeedProjection {
+  needId: EntityId;
+  requestedQuantity?: Quantity;
+  fulfilledQuantity?: Quantity;
+  remainingQuantity?: Quantity;
+  fulfillmentCount: number;
+  status: "open" | "paused" | "partially_answered" | "scope_answered" | "withdrawn" | "unknown";
+  stillCalling: boolean;
+  confidence: "known" | "partial" | "unknown";
+  lastFulfillmentId?: EntityId;
+  derivedAt: ISO8601;
+}
+
+function requireCondition(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+function forbidCondition(condition: boolean, message: string): void {
+  if (condition) throw new Error(message);
+}
+
+export function validateNeedDeclared(need: Record<string, unknown>): void {
+  if ("status" in need) {
+    throw new Error("NeedDeclared must not contain status; status is derived projection state");
+  }
+  if ("stillCalling" in need) {
+    throw new Error("NeedDeclared must not contain stillCalling; it is derived projection state");
+  }
+  if ("canonicalHash" in need) {
+    throw new Error("NeedDeclared must not contain canonicalHash; identity is external to the hashed body");
+  }
+  if ("subjectConsent" in need) {
+    throw new Error("subjectConsent is not fulfillment authority; use disclosurePolicy explicitly");
+  }
+}
+
+export function validateFulfillmentReceipt(receipt: FulfillmentRecorded): void {
+  requireCondition(Boolean(receipt.needId), "needId required");
+  requireCondition(Boolean(receipt.needSnapshotHash), "needSnapshotHash required");
+  requireCondition(Boolean(receipt.origin), "origin required");
+  requireCondition(Boolean(receipt.outcome), "outcome required");
+  requireCondition(Boolean(receipt.fulfillment.kind), "fulfillment.kind required");
+  requireCondition(Boolean(receipt.fulfillment.summary), "fulfillment.summary required");
+  requireCondition(Boolean(receipt.disclosurePolicy), "disclosurePolicy required");
+
+  const hasJoin = Boolean(receipt.joinId);
+  const hasOfferIds = Boolean(receipt.offerIds?.length);
+  const hasOfferId = Boolean(receipt.offerId);
+  const hasExternal = Boolean(receipt.externalProvenance);
+
+  switch (receipt.origin) {
+    case "joined_offer":
+      requireCondition(hasJoin, "joined_offer origin requires joinId");
+      forbidCondition(hasExternal, "joined_offer must not invent externalProvenance");
+      break;
+    case "direct_response":
+      forbidCondition(hasJoin, "direct_response must not have joinId");
+      forbidCondition(hasOfferIds, "direct_response must not have offerIds");
+      forbidCondition(hasOfferId, "direct_response must not claim offerId");
+      forbidCondition(hasExternal, "direct_response must not have externalProvenance");
+      break;
+    case "external":
+      requireCondition(hasExternal, "external origin requires externalProvenance");
+      requireCondition(Boolean(receipt.externalProvenance?.sourceRef), "externalProvenance.sourceRef required");
+      forbidCondition(hasJoin, "external origin must not claim joinId");
+      break;
+    case "unknown":
+      forbidCondition(hasJoin, "unknown origin must not have joinId");
+      forbidCondition(hasOfferIds, "unknown origin must not have offerIds");
+      forbidCondition(hasOfferId, "unknown origin must not have offerId");
+      forbidCondition(hasExternal, "unknown origin must not invent externalProvenance");
+      break;
+  }
+}
+
+export function deriveProjectionConfidence(
+  need: NeedDeclared,
+  fulfillments: readonly FulfillmentRecorded[],
+): NeedProjection["confidence"] {
+  if (!need.requestedQuantity) return "unknown";
+  const applicable = fulfillments.filter((receipt) => receipt.outcome !== "attempted");
+  if (
+    applicable.some(
+      (receipt) =>
+        !receipt.fulfillment.quantity ||
+        receipt.fulfillment.quantity.unit !== need.requestedQuantity?.unit ||
+        receipt.outcome === "scope_uncertain",
+    )
+  ) {
+    return "partial";
+  }
+  return "known";
+}
+
+export function projectNeed(
+  need: NeedDeclared,
+  fulfillments: readonly FulfillmentRecorded[],
+  lifecycle: readonly { type: "NEED_PAUSED" | "NEED_WITHDRAWN"; recordedAt: ISO8601 }[] = [],
+  now: ISO8601,
+): NeedProjection {
+  const requested = need.requestedQuantity;
+  let fulfilledValue = 0;
+
+  for (const receipt of fulfillments) {
+    if (receipt.outcome === "attempted") continue;
+    if (requested && receipt.fulfillment.quantity?.unit === requested.unit) {
+      fulfilledValue += receipt.fulfillment.quantity.value;
+    }
+  }
+
+  const fulfilledQuantity = requested ? { value: fulfilledValue, unit: requested.unit } : undefined;
+  const remainingQuantity = requested
+    ? { value: Math.max(0, requested.value - fulfilledValue), unit: requested.unit }
+    : undefined;
+
+  let status: NeedProjection["status"] = "open";
+  const lastLifecycle = lifecycle.at(-1);
+  if (lastLifecycle?.type === "NEED_PAUSED") status = "paused";
+  else if (lastLifecycle?.type === "NEED_WITHDRAWN") status = "withdrawn";
+  else if (remainingQuantity?.value === 0) status = "scope_answered";
+  else if (fulfilledValue > 0) status = "partially_answered";
+
+  const projection: NeedProjection = {
+    needId: need.id,
+    fulfillmentCount: fulfillments.length,
+    status,
+    stillCalling: status === "open" || status === "partially_answered",
+    confidence: deriveProjectionConfidence(need, fulfillments),
+    derivedAt: now,
+  };
+  if (requested) projection.requestedQuantity = requested;
+  if (fulfilledQuantity) projection.fulfilledQuantity = fulfilledQuantity;
+  if (remainingQuantity) projection.remainingQuantity = remainingQuantity;
+  const lastFulfillmentId = fulfillments.at(-1)?.id;
+  if (lastFulfillmentId) projection.lastFulfillmentId = lastFulfillmentId;
+  return projection;
+}

--- a/test/fulfillment.test.ts
+++ b/test/fulfillment.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { FilesystemArtifactStore } from "../src/artifact-store.js";
+import {
+  deriveProjectionConfidence,
+  projectNeed,
+  validateFulfillmentReceipt,
+  validateNeedDeclared,
+  type FulfillmentRecorded,
+  type NeedDeclared,
+} from "../src/fulfillment.js";
+import { verifyFulfillmentAgainstSubstrate } from "../src/fulfillment-substrate.js";
+import {
+  addressFieldRootAdmission,
+  addressProjectionReceipt,
+  type ProjectionGraph,
+} from "../src/projection.js";
+import { addressJson, type ResidualBinding, type SampleLocator } from "../src/residual.js";
+import { extractPcmResidualFromStore } from "../src/wav-pcm.js";
+
+const disclosurePolicy = {
+  audience: "circle" as const,
+  permittedFields: {
+    summary: true,
+    quantity: true,
+    coarseTime: true,
+    coarsePlace: false,
+    exactPlace: false,
+    participantIdentity: false,
+    artifacts: false,
+  },
+  basis: "aggregate_only" as const,
+};
+
+async function canonicalNeedFixture(): Promise<NeedDeclared> {
+  const bytes = await readFile("fixtures/canonical/fulfillment/need_breakfast_001.json", "utf8");
+  return JSON.parse(bytes) as NeedDeclared;
+}
+
+async function storeFor(t: TestContext): Promise<FilesystemArtifactStore> {
+  const root = await mkdtemp(join(tmpdir(), "tranchnode-fulfillment-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return new FilesystemArtifactStore(root);
+}
+
+function pcm16(samples: number[]): Buffer {
+  const bytes = Buffer.alloc(samples.length * 2);
+  samples.forEach((sample, index) => bytes.writeInt16LE(sample, index * 2));
+  return bytes;
+}
+
+function chunk(id: string, payload: Uint8Array): Buffer {
+  const pad = payload.byteLength & 1;
+  const out = Buffer.alloc(8 + payload.byteLength + pad);
+  out.write(id, 0, 4, "ascii");
+  out.writeUInt32LE(payload.byteLength, 4);
+  Buffer.from(payload).copy(out, 8);
+  return out;
+}
+
+function wav16(samples: number[], sampleRateHz = 48_000): Buffer {
+  const fmt = Buffer.alloc(16);
+  fmt.writeUInt16LE(1, 0);
+  fmt.writeUInt16LE(1, 2);
+  fmt.writeUInt32LE(sampleRateHz, 4);
+  fmt.writeUInt32LE(sampleRateHz * 2, 8);
+  fmt.writeUInt16LE(2, 12);
+  fmt.writeUInt16LE(16, 14);
+  const waveBody = Buffer.concat([
+    Buffer.from("WAVE", "ascii"),
+    chunk("fmt ", fmt),
+    chunk("data", pcm16(samples)),
+  ]);
+  const out = Buffer.alloc(8 + waveBody.byteLength);
+  out.write("RIFF", 0, 4, "ascii");
+  out.writeUInt32LE(waveBody.byteLength, 4);
+  waveBody.copy(out, 8);
+  return out;
+}
+
+test("canonical fulfillment fixture uses shared external identity", async () => {
+  const need = await canonicalNeedFixture();
+  validateNeedDeclared(need as unknown as Record<string, unknown>);
+  assert.equal("canonicalHash" in need, false);
+  assert.match(addressJson(need).hash, /^sha256:[0-9a-f]{64}$/);
+  assert.throws(
+    () => validateNeedDeclared({ ...need, canonicalHash: addressJson(need).hash }),
+    /identity is external/,
+  );
+});
+
+test("origin law preserves unknown provenance and derived Need state", async () => {
+  const need = await canonicalNeedFixture();
+  const needHash = addressJson(need).hash;
+  const base: FulfillmentRecorded = {
+    id: "fulfillment_001",
+    type: "FULFILLMENT_RECORDED",
+    version: 1,
+    needId: need.id,
+    needSnapshotHash: needHash,
+    origin: "direct_response",
+    outcome: "partial",
+    occurredAt: "2026-07-31T12:00:00Z",
+    recordedAt: "2026-07-31T12:05:00Z",
+    recordedBy: "actor_fixture",
+    fulfillment: { kind: "meal", summary: "Twenty-two meals arrived.", quantity: { value: 22, unit: "meal" } },
+    visibility: "circle",
+    disclosurePolicy,
+  };
+
+  assert.doesNotThrow(() => validateFulfillmentReceipt(base));
+  assert.throws(
+    () => validateFulfillmentReceipt({ ...base, origin: "unknown", joinId: "invented_join" }),
+    /unknown origin/,
+  );
+
+  const projection = projectNeed(need, [base], [], "2026-07-31T13:00:00Z");
+  assert.equal(projection.fulfilledQuantity?.value, 22);
+  assert.equal(projection.remainingQuantity?.value, 11);
+  assert.equal(projection.status, "partially_answered");
+  assert.equal(projection.stillCalling, true);
+  assert.equal(deriveProjectionConfidence(need, [base]), "known");
+  assert.equal("status" in need, false);
+});
+
+test("fulfillment verifies through identity, immutable storage, root closure, and real WAV residuals", async (t) => {
+  const store = await storeFor(t);
+  const need = await canonicalNeedFixture();
+  const needHash = addressJson(need).hash;
+
+  const wav = wav16([100, -100, 200, -200]);
+  const storedWav = await store.put(wav);
+  const locator: SampleLocator = {
+    locatorVersion: "sample-v1",
+    sourceArtifact: storedWav.address,
+    sampleRateHz: 48_000,
+    channels: 1,
+    sampleFormat: "s16le",
+    startSample: 1,
+    endSampleExclusive: 3,
+  };
+  const extracted = await extractPcmResidualFromStore(store, locator);
+  const residual: ResidualBinding = {
+    id: "meal-arrival-audio",
+    source: locator,
+    extractedPayloadHash: extracted.payloadHash,
+    preservationBasis: "testimonial",
+    preservationMode: "exact_samples",
+  };
+
+  const material = await store.put(Buffer.from("fixture material receipt", "utf8"));
+  const purposeHash = addressJson({ purpose: "fulfillment evidence fixture" }).hash;
+  const admission = addressFieldRootAdmission({
+    kind: "field_root_admission",
+    fieldRoot: storedWav.address,
+    admittedBy: { id: "fulfillment-kernel-test", version: "1" },
+    purposeHash,
+    creationOrder: 1,
+  });
+  const projection = addressProjectionReceipt({
+    kind: "projection_receipt",
+    projectionKind: "observation",
+    fieldRoots: [storedWav.address],
+    parentProjectionHashes: [],
+    rootAdmissionReceiptHashes: [admission.hash],
+    projector: { id: "fulfillment-kernel-test", version: "1" },
+    questionPurposeHash: purposeHash,
+    contextHashes: [],
+    outputNodeHashes: [material.address],
+    residualHashes: [extracted.payloadHash],
+    uncertainty: "Fixture observation only; witness does not certify objective success.",
+    creationOrder: 2,
+  });
+  const graph: ProjectionGraph = {
+    projections: new Map([[projection.hash, projection]]),
+    admissions: new Map([[admission.hash, admission]]),
+  };
+
+  const receipt: FulfillmentRecorded = {
+    id: "fulfillment_substrate_001",
+    type: "FULFILLMENT_RECORDED",
+    version: 1,
+    needId: need.id,
+    needSnapshotHash: needHash,
+    origin: "direct_response",
+    outcome: "partial",
+    occurredAt: "2026-07-31T12:00:00Z",
+    recordedAt: "2026-07-31T12:05:00Z",
+    recordedBy: "actor_fixture",
+    fulfillment: { kind: "meal", summary: "Material response reported at the table.", quantity: { value: 1, unit: "meal" } },
+    visibility: "circle",
+    disclosurePolicy,
+    materialArtifactHashes: [material.address],
+    projectionReceiptHash: projection.hash,
+    residualIds: [residual.id],
+  };
+
+  const verified = await verifyFulfillmentAgainstSubstrate(
+    need,
+    receipt,
+    { projection: { target: projection, graph }, residualBindings: [residual] },
+    store,
+  );
+
+  assert.equal(verified.need.hash, needHash);
+  assert.equal(verified.fulfillment.hash, addressJson(receipt).hash);
+  assert.deepEqual(verified.materialArtifactHashes, [material.address]);
+  assert.deepEqual(verified.fieldRoots, [storedWav.address]);
+  assert.deepEqual(verified.residualIds, [residual.id]);
+});


### PR DESCRIPTION
Closes #9

## What this reconciles

- removes fulfillment-local/self-referential canonical identity; canonical Need and fulfillment bodies are addressed through the shared `addressJson` path;
- preserves Need-centered fulfillment semantics, origin/provenance constraints, disclosure boundaries, and derived Need projection behavior;
- adds `verifyFulfillmentAgainstSubstrate` as a composition seam over the already-landed immutable artifact store, projection/root-closure verifier, and WAV PCM residual verifier;
- keeps generic substrate modules free of fulfillment vocabulary;
- restores explicit draft/canonical fulfillment fixture discipline without embedding identity inside hashed bodies;
- proves one canonical fixture across the complete floor: shared identity → immutable material store → field-root closure → exact WAV residual → externally addressed fulfillment receipt.

## Deliberate non-goals

No new canonicalizer, no fulfillment-local storage, no projection reinterpretation, no residual format expansion, and no philosophical backlog expansion.

## Validation

The branch includes repository-native `test/fulfillment.test.ts` coverage. Local shell validation could not be run because this environment cannot resolve github.com for dependency checkout, so GitHub Actions is the authoritative branch check for this PR.