### PR TITLE
Add fulfillment crossing proof

### DIFF
--- a/src/fulfillment.ts
+++ b/src/fulfillment.ts
@@ -1,0 +1,213 @@
+import type {
+  MaterialRootStore,
+  ProjectionGraph,
+  ProjectionReceipt,
+} from "./projection.js";
+import { verifyProjectionWithMaterialRoots } from "./projection.js";
+import type { Addressed, Hash, ResidualBinding } from "./residual.js";
+import { addressJson } from "./residual.js";
+import { verifyExactPcmResidual } from "./wav-pcm.js";
+
+export type FulfillmentOutcome =
+  | "attempted"
+  | "partial"
+  | "scoped_complete"
+  | "scope_uncertain";
+
+export type FulfillmentOrigin =
+  | "joined_offer"
+  | "direct_response"
+  | "external"
+  | "unknown";
+
+export interface Quantity {
+  value: number;
+  unit: string;
+}
+
+export interface NeedDeclared {
+  kind: "need_declared";
+  summary: string;
+  requestedQuantity?: Quantity;
+}
+
+export interface ExternalProvenance {
+  sourceRef: string;
+  sourceHash?: Hash;
+}
+
+export interface FulfillmentRecorded {
+  kind: "fulfillment_recorded";
+  needHash: Hash;
+  evidenceProjectionHash: Hash;
+  residualHashes: Hash[];
+  origin: FulfillmentOrigin;
+  joinHash?: Hash;
+  offerHash?: Hash;
+  externalProvenance?: ExternalProvenance;
+  outcome: FulfillmentOutcome;
+  fulfillment: {
+    kind: string;
+    summary: string;
+    quantity?: Quantity;
+  };
+  occurredAt: string;
+  recordedAt: string;
+  recordedBy: string;
+  uncertainty: string;
+}
+
+export interface FulfillmentVerification {
+  fieldRoots: ReadonlySet<Hash>;
+  verifiedResidualHashes: readonly Hash[];
+}
+
+export class FulfillmentError extends Error {
+  constructor(
+    public readonly code:
+      | "NEED_IDENTITY_MISMATCH"
+      | "FULFILLMENT_IDENTITY_MISMATCH"
+      | "NEED_REFERENCE_MISMATCH"
+      | "EVIDENCE_PROJECTION_REFERENCE_MISMATCH"
+      | "EVIDENCE_NOT_OBSERVATION"
+      | "ORIGIN_PROVENANCE_MISMATCH"
+      | "MISSING_RESIDUAL"
+      | "RESIDUAL_IDENTITY_MISMATCH"
+      | "RESIDUAL_NOT_IN_PROJECTION",
+    message: string,
+  ) {
+    super(message);
+    this.name = "FulfillmentError";
+  }
+}
+
+export function addressNeed(need: NeedDeclared): Addressed<NeedDeclared> {
+  return addressJson(need);
+}
+
+export function addressFulfillment(
+  fulfillment: FulfillmentRecorded,
+): Addressed<FulfillmentRecorded> {
+  validateFulfillmentSemantics(fulfillment);
+  return addressJson(fulfillment);
+}
+
+export function validateFulfillmentSemantics(fulfillment: FulfillmentRecorded): void {
+  const hasJoin = fulfillment.joinHash !== undefined;
+  const hasOffer = fulfillment.offerHash !== undefined;
+  const hasExternal = fulfillment.externalProvenance !== undefined;
+
+  switch (fulfillment.origin) {
+    case "joined_offer":
+      if (!hasJoin || !hasOffer || hasExternal) {
+        throw new FulfillmentError(
+          "ORIGIN_PROVENANCE_MISMATCH",
+          "joined_offer requires joinHash and offerHash and forbids external provenance",
+        );
+      }
+      break;
+    case "direct_response":
+      if (hasJoin || hasOffer || hasExternal) {
+        throw new FulfillmentError(
+          "ORIGIN_PROVENANCE_MISMATCH",
+          "direct_response must not claim join, offer, or external provenance",
+        );
+      }
+      break;
+    case "external":
+      if (
+        !hasExternal ||
+        !fulfillment.externalProvenance?.sourceRef ||
+        hasJoin ||
+        hasOffer
+      ) {
+        throw new FulfillmentError(
+          "ORIGIN_PROVENANCE_MISMATCH",
+          "external origin requires a sourceRef and must not claim join or offer lineage",
+        );
+      }
+      break;
+    case "unknown":
+      if (hasJoin || hasOffer || hasExternal) {
+        throw new FulfillmentError(
+          "ORIGIN_PROVENANCE_MISMATCH",
+          "unknown origin must remain unknown; provenance may not be silently invented",
+        );
+      }
+      break;
+  }
+}
+
+export async function verifyFulfillmentCrossing(input: {
+  need: Addressed<NeedDeclared>;
+  fulfillment: Addressed<FulfillmentRecorded>;
+  evidenceProjection: Addressed<ProjectionReceipt>;
+  projectionGraph: ProjectionGraph;
+  store: MaterialRootStore;
+  residuals: ReadonlyMap<Hash, Addressed<ResidualBinding>>;
+}): Promise<FulfillmentVerification> {
+  assertAddressIdentity(input.need, "NEED_IDENTITY_MISMATCH");
+  assertAddressIdentity(input.fulfillment, "FULFILLMENT_IDENTITY_MISMATCH");
+  validateFulfillmentSemantics(input.fulfillment.value);
+
+  if (input.fulfillment.value.needHash !== input.need.hash) {
+    throw new FulfillmentError(
+      "NEED_REFERENCE_MISMATCH",
+      `Fulfillment references ${input.fulfillment.value.needHash}, not need ${input.need.hash}`,
+    );
+  }
+  if (input.fulfillment.value.evidenceProjectionHash !== input.evidenceProjection.hash) {
+    throw new FulfillmentError(
+      "EVIDENCE_PROJECTION_REFERENCE_MISMATCH",
+      "Fulfillment does not reference the supplied evidence projection",
+    );
+  }
+  if (input.evidenceProjection.value.projectionKind !== "observation") {
+    throw new FulfillmentError(
+      "EVIDENCE_NOT_OBSERVATION",
+      "Fulfillment evidence must be an observation projection; proposal or tension is not witness evidence",
+    );
+  }
+
+  const fieldRoots = await verifyProjectionWithMaterialRoots(
+    input.evidenceProjection,
+    input.projectionGraph,
+    input.store,
+  );
+
+  const verifiedResidualHashes: Hash[] = [];
+  for (const residualHash of input.fulfillment.value.residualHashes) {
+    if (!input.evidenceProjection.value.residualHashes.includes(residualHash)) {
+      throw new FulfillmentError(
+        "RESIDUAL_NOT_IN_PROJECTION",
+        `Fulfillment cites residual ${residualHash} that the evidence projection does not cite`,
+      );
+    }
+    const residual = input.residuals.get(residualHash);
+    if (!residual) {
+      throw new FulfillmentError(
+        "MISSING_RESIDUAL",
+        `Fulfillment cites unavailable residual ${residualHash}`,
+      );
+    }
+    if (addressJson(residual.value).hash !== residual.hash || residual.hash !== residualHash) {
+      throw new FulfillmentError(
+        "RESIDUAL_IDENTITY_MISMATCH",
+        `Residual body does not match declared identity ${residualHash}`,
+      );
+    }
+    await verifyExactPcmResidual(input.store, residual.value);
+    verifiedResidualHashes.push(residualHash);
+  }
+
+  return { fieldRoots, verifiedResidualHashes };
+}
+
+function assertAddressIdentity<T>(
+  addressed: Addressed<T>,
+  code: "NEED_IDENTITY_MISMATCH" | "FULFILLMENT_IDENTITY_MISMATCH",
+): void {
+  if (addressJson(addressed.value).hash !== addressed.hash) {
+    throw new FulfillmentError(code, `Addressed body does not match ${addressed.hash}`);
+  }
+}

--- a/test/fulfillment.test.ts
+++ b/test/fulfillment.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { FilesystemArtifactStore } from "../src/artifact-store.js";
+import {
+  addressFulfillment,
+  addressNeed,
+  FulfillmentError,
+  validateFulfillmentSemantics,
+  verifyFulfillmentCrossing,
+  type FulfillmentRecorded,
+} from "../src/fulfillment.js";
+import {
+  addressFieldRootAdmission,
+  addressProjectionReceipt,
+  type ProjectionGraph,
+} from "../src/projection.js";
+import {
+  addressJson,
+  sha256,
+  type ResidualBinding,
+  type SampleLocator,
+} from "../src/residual.js";
+
+function pcm16(samples: number[]): Buffer {
+  const bytes = Buffer.alloc(samples.length * 2);
+  samples.forEach((sample, index) => bytes.writeInt16LE(sample, index * 2));
+  return bytes;
+}
+
+function chunk(id: string, payload: Uint8Array): Buffer {
+  const pad = payload.byteLength & 1;
+  const out = Buffer.alloc(8 + payload.byteLength + pad);
+  out.write(id, 0, 4, "ascii");
+  out.writeUInt32LE(payload.byteLength, 4);
+  Buffer.from(payload).copy(out, 8);
+  return out;
+}
+
+function wav16(samples: number[], sampleRateHz = 48_000): Buffer {
+  const fmt = Buffer.alloc(16);
+  fmt.writeUInt16LE(1, 0);
+  fmt.writeUInt16LE(1, 2);
+  fmt.writeUInt32LE(sampleRateHz, 4);
+  fmt.writeUInt32LE(sampleRateHz * 2, 8);
+  fmt.writeUInt16LE(2, 12);
+  fmt.writeUInt16LE(16, 14);
+
+  const waveBody = Buffer.concat([
+    Buffer.from("WAVE", "ascii"),
+    chunk("fmt ", fmt),
+    chunk("data", pcm16(samples)),
+  ]);
+  const out = Buffer.alloc(8 + waveBody.byteLength);
+  out.write("RIFF", 0, 4, "ascii");
+  out.writeUInt32LE(waveBody.byteLength, 4);
+  waveBody.copy(out, 8);
+  return out;
+}
+
+async function storeFor(t: TestContext): Promise<FilesystemArtifactStore> {
+  const root = await mkdtemp(join(tmpdir(), "tranchnode-fulfillment-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return new FilesystemArtifactStore(root);
+}
+
+function locator(sourceArtifact: SampleLocator["sourceArtifact"]): SampleLocator {
+  return {
+    locatorVersion: "sample-v1",
+    sourceArtifact,
+    sampleRateHz: 48_000,
+    channels: 1,
+    sampleFormat: "s16le",
+    startSample: 1,
+    endSampleExclusive: 3,
+  };
+}
+
+test("fulfillment crossing derives a new receipt while exact source and root closure remain intact", async (t) => {
+  const store = await storeFor(t);
+  const source = wav16([100, -100, 200, -200]);
+  const stored = await store.put(source);
+  const sourceBefore = await store.get(stored.address);
+
+  const residualBinding: ResidualBinding = {
+    id: "meal-table-audio-evidence",
+    source: locator(stored.address),
+    extractedPayloadHash: sha256(pcm16([-100, 200])),
+    preservationBasis: "testimonial",
+    preservationMode: "exact_samples",
+  };
+  const residual = addressJson(residualBinding);
+
+  const admission = addressFieldRootAdmission({
+    kind: "field_root_admission",
+    fieldRoot: stored.address,
+    admittedBy: { id: "fulfillment-fixture", version: "1" },
+    purposeHash: sha256(Buffer.from("admit exact fulfillment evidence")),
+    creationOrder: 0,
+  });
+  const projection = addressProjectionReceipt({
+    kind: "projection_receipt",
+    projectionKind: "observation",
+    fieldRoots: [stored.address],
+    parentProjectionHashes: [],
+    rootAdmissionReceiptHashes: [admission.hash],
+    projector: { id: "fulfillment-fixture", version: "1" },
+    questionPurposeHash: sha256(Buffer.from("what material response was observed")),
+    contextHashes: [],
+    outputNodeHashes: [],
+    residualHashes: [residual.hash],
+    uncertainty: "receipt records scoped observation, not objective or moral completion",
+    creationOrder: 1,
+  });
+  const graph: ProjectionGraph = {
+    projections: new Map([[projection.hash, projection]]),
+    admissions: new Map([[admission.hash, admission]]),
+  };
+
+  const need = addressNeed({
+    kind: "need_declared",
+    summary: "Provide two meals at the morning table",
+    requestedQuantity: { value: 2, unit: "meal" },
+  });
+  const fulfillment = addressFulfillment({
+    kind: "fulfillment_recorded",
+    needHash: need.hash,
+    evidenceProjectionHash: projection.hash,
+    residualHashes: [residual.hash],
+    origin: "unknown",
+    outcome: "partial",
+    fulfillment: {
+      kind: "meal",
+      summary: "One meal was reported present at the table",
+      quantity: { value: 1, unit: "meal" },
+    },
+    occurredAt: "2026-08-07T12:00:00Z",
+    recordedAt: "2026-08-07T12:01:00Z",
+    recordedBy: "fixture-witness",
+    uncertainty: "origin remains unknown; material evidence is exact only for the cited PCM residual",
+  });
+
+  const verified = await verifyFulfillmentCrossing({
+    need,
+    fulfillment,
+    evidenceProjection: projection,
+    projectionGraph: graph,
+    store,
+    residuals: new Map([[residual.hash, residual]]),
+  });
+
+  const sourceAfter = await store.get(stored.address);
+  assert.deepEqual(sourceAfter, sourceBefore);
+  assert.equal(sha256(sourceAfter), stored.address);
+  assert.notEqual(fulfillment.hash, need.hash);
+  assert.notEqual(fulfillment.hash, projection.hash);
+  assert.deepEqual([...verified.fieldRoots], [stored.address]);
+  assert.deepEqual(verified.verifiedResidualHashes, [residual.hash]);
+});
+
+test("unknown fulfillment origin cannot silently acquire invented provenance", () => {
+  const bad: FulfillmentRecorded = {
+    kind: "fulfillment_recorded",
+    needHash: sha256(Buffer.from("need")),
+    evidenceProjectionHash: sha256(Buffer.from("projection")),
+    residualHashes: [],
+    origin: "unknown",
+    externalProvenance: { sourceRef: "someone-said-so" },
+    outcome: "scope_uncertain",
+    fulfillment: { kind: "meal", summary: "Reported response" },
+    occurredAt: "2026-08-07T12:00:00Z",
+    recordedAt: "2026-08-07T12:01:00Z",
+    recordedBy: "fixture-witness",
+    uncertainty: "origin unavailable",
+  };
+
+  assert.throws(
+    () => validateFulfillmentSemantics(bad),
+    (error: unknown) =>
+      error instanceof FulfillmentError && error.code === "ORIGIN_PROVENANCE_MISMATCH",
+  );
+});
+
+test("fulfillment cannot cite residual evidence absent from its observation projection", async (t) => {
+  const store = await storeFor(t);
+  const source = wav16([1, 2, 3, 4]);
+  const stored = await store.put(source);
+  const residualBinding: ResidualBinding = {
+    id: "unprojected-residual",
+    source: locator(stored.address),
+    extractedPayloadHash: sha256(pcm16([2, 3])),
+    preservationBasis: "testimonial",
+    preservationMode: "exact_samples",
+  };
+  const residual = addressJson(residualBinding);
+  const admission = addressFieldRootAdmission({
+    kind: "field_root_admission",
+    fieldRoot: stored.address,
+    admittedBy: { id: "fulfillment-fixture", version: "1" },
+    purposeHash: sha256(Buffer.from("admit source")),
+    creationOrder: 0,
+  });
+  const projection = addressProjectionReceipt({
+    kind: "projection_receipt",
+    projectionKind: "observation",
+    fieldRoots: [stored.address],
+    parentProjectionHashes: [],
+    rootAdmissionReceiptHashes: [admission.hash],
+    projector: { id: "fulfillment-fixture", version: "1" },
+    questionPurposeHash: sha256(Buffer.from("observe response")),
+    contextHashes: [],
+    outputNodeHashes: [],
+    residualHashes: [],
+    uncertainty: "fixture",
+    creationOrder: 1,
+  });
+  const graph: ProjectionGraph = {
+    projections: new Map([[projection.hash, projection]]),
+    admissions: new Map([[admission.hash, admission]]),
+  };
+  const need = addressNeed({ kind: "need_declared", summary: "Need" });
+  const fulfillment = addressFulfillment({
+    kind: "fulfillment_recorded",
+    needHash: need.hash,
+    evidenceProjectionHash: projection.hash,
+    residualHashes: [residual.hash],
+    origin: "unknown",
+    outcome: "scope_uncertain",
+    fulfillment: { kind: "meal", summary: "Reported response" },
+    occurredAt: "2026-08-07T12:00:00Z",
+    recordedAt: "2026-08-07T12:01:00Z",
+    recordedBy: "fixture-witness",
+    uncertainty: "fixture",
+  });
+
+  await assert.rejects(
+    () =>
+      verifyFulfillmentCrossing({
+        need,
+        fulfillment,
+        evidenceProjection: projection,
+        projectionGraph: graph,
+        store,
+        residuals: new Map([[residual.hash, residual]]),
+      }),
+    (error: unknown) =>
+      error instanceof FulfillmentError && error.code === "RESIDUAL_NOT_IN_PROJECTION",
+  );
+});


### PR DESCRIPTION
## What changed

Begins #9 with one narrow executable crossing rather than reviving the historical fulfillment branch wholesale.

- adds `NeedDeclared` and `FulfillmentRecorded` as fulfillment-specific semantic bodies addressed through the existing `addressJson` identity floor;
- keeps computed identity outside the hashed body;
- requires fulfillment material evidence to reference an `observation` projection rather than treating proposal/tension as witness;
- verifies #7 field-root closure and material-root availability through the existing projection/store APIs;
- verifies every cited exact WAV PCM residual through the landed #8 extractor;
- preserves origin-specific provenance rules, including the right for origin to remain `unknown` without invented lineage;
- adds a characterization test proving that the fulfillment receipt is a new addressed derivative while the stored source bytes and source identity remain unchanged;
- adds fail-closed coverage for invented provenance and residual evidence not actually present in the observation projection.

## Why

This is the smallest honest first slice of #9. It exercises the now-landed chain:

`canonical identity -> immutable store -> projection/root closure -> real WAV residual -> fulfillment receipt`

without introducing a second canonicalizer, mutating source evidence, or importing the full historical ontology before its pieces are reconciled.

Conceptually this is the useful engineering residue of the recent “transformation covenant” discussion: receive exact evidence, derive a separately addressed form, retain ancestry/root closure, and never let projection or fulfillment silently replace source.

## Scope intentionally deferred

- full Offer/Join event bodies and lineage verification;
- Need lifecycle/projection reconstruction;
- disclosure projection machinery;
- fixture minting/canonical fixture migration;
- broader historical PR #1 ontology.

Those should follow only after this crossing proof is mechanically sound.

Closes no issue yet; advances #9.