### PR TITLE
Bind fulfillment evidence to observation and cited residuals

### DIFF
--- a/src/fulfillment-substrate.ts
+++ b/src/fulfillment-substrate.ts
@@ -34,8 +34,10 @@ export class FulfillmentKernelError extends Error {
       | "NEED_SNAPSHOT_MISMATCH"
       | "PROJECTION_EVIDENCE_MISSING"
       | "PROJECTION_REFERENCE_MISMATCH"
+      | "EVIDENCE_NOT_OBSERVATION"
       | "RESIDUAL_EVIDENCE_MISSING"
       | "RESIDUAL_REFERENCE_MISMATCH"
+      | "RESIDUAL_NOT_IN_PROJECTION"
       | "DUPLICATE_RESIDUAL_ID",
     message: string,
   ) {
@@ -92,6 +94,12 @@ export async function verifyFulfillmentAgainstSubstrate(
         `Fulfillment ${receipt.id} references ${receipt.projectionReceiptHash}, evidence supplied ${evidence.projection.target.hash}`,
       );
     }
+    if (evidence.projection.target.value.projectionKind !== "observation") {
+      throw new FulfillmentKernelError(
+        "EVIDENCE_NOT_OBSERVATION",
+        `Fulfillment ${receipt.id} evidence must be an observation projection, not ${evidence.projection.target.value.projectionKind}`,
+      );
+    }
     fieldRoots = [...await verifyProjectionWithMaterialRoots(
       evidence.projection.target,
       evidence.projection.graph,
@@ -135,6 +143,17 @@ export async function verifyFulfillmentAgainstSubstrate(
         `Residual ${id} was referenced but not supplied`,
       );
     }
+
+    if (
+      evidence.projection
+      && !evidence.projection.target.value.residualHashes.includes(addressJson(binding).hash)
+    ) {
+      throw new FulfillmentKernelError(
+        "RESIDUAL_NOT_IN_PROJECTION",
+        `Residual ${id} is exact material evidence but is not cited by observation projection ${evidence.projection.target.hash}`,
+      );
+    }
+
     await verifyExactPcmResidual(store, binding);
   }
 

--- a/test/fulfillment.test.ts
+++ b/test/fulfillment.test.ts
@@ -12,7 +12,10 @@ import {
   type FulfillmentRecorded,
   type NeedDeclared,
 } from "../src/fulfillment.js";
-import { verifyFulfillmentAgainstSubstrate } from "../src/fulfillment-substrate.js";
+import {
+  FulfillmentKernelError,
+  verifyFulfillmentAgainstSubstrate,
+} from "../src/fulfillment-substrate.js";
 import {
   addressFieldRootAdmission,
   addressProjectionReceipt,
@@ -126,13 +129,14 @@ test("origin law preserves unknown provenance and derived Need state", async () 
   assert.equal("status" in need, false);
 });
 
-test("fulfillment verifies through identity, immutable storage, root closure, and real WAV residuals", async (t) => {
+test("fulfillment crossing binds observation, root closure, and exact WAV residual evidence without mutating source", async (t) => {
   const store = await storeFor(t);
   const need = await canonicalNeedFixture();
   const needHash = addressJson(need).hash;
 
   const wav = wav16([100, -100, 200, -200]);
   const storedWav = await store.put(wav);
+  const sourceBefore = await store.get(storedWav.address);
   const locator: SampleLocator = {
     locatorVersion: "sample-v1",
     sourceArtifact: storedWav.address,
@@ -150,6 +154,7 @@ test("fulfillment verifies through identity, immutable storage, root closure, an
     preservationBasis: "testimonial",
     preservationMode: "exact_samples",
   };
+  const residualHash = addressJson(residual).hash;
 
   const material = await store.put(Buffer.from("fixture material receipt", "utf8"));
   const purposeHash = addressJson({ purpose: "fulfillment evidence fixture" }).hash;
@@ -170,7 +175,7 @@ test("fulfillment verifies through identity, immutable storage, root closure, an
     questionPurposeHash: purposeHash,
     contextHashes: [],
     outputNodeHashes: [material.address],
-    residualHashes: [extracted.payloadHash],
+    residualHashes: [residualHash],
     uncertainty: "Fixture observation only; witness does not certify objective success.",
     creationOrder: 2,
   });
@@ -207,7 +212,56 @@ test("fulfillment verifies through identity, immutable storage, root closure, an
 
   assert.equal(verified.need.hash, needHash);
   assert.equal(verified.fulfillment.hash, addressJson(receipt).hash);
+  assert.notEqual(verified.fulfillment.hash, storedWav.address);
   assert.deepEqual(verified.materialArtifactHashes, [material.address]);
   assert.deepEqual(verified.fieldRoots, [storedWav.address]);
   assert.deepEqual(verified.residualIds, [residual.id]);
+  assert.deepEqual(await store.get(storedWav.address), sourceBefore);
+
+  const proposal = addressProjectionReceipt({
+    ...projection.value,
+    projectionKind: "proposal",
+  });
+  const proposalReceipt: FulfillmentRecorded = {
+    ...receipt,
+    projectionReceiptHash: proposal.hash,
+  };
+  await assert.rejects(
+    () => verifyFulfillmentAgainstSubstrate(
+      need,
+      proposalReceipt,
+      {
+        projection: {
+          target: proposal,
+          graph: {
+            projections: new Map([[proposal.hash, proposal]]),
+            admissions: new Map([[admission.hash, admission]]),
+          },
+        },
+        residualBindings: [residual],
+      },
+      store,
+    ),
+    (error: unknown) => error instanceof FulfillmentKernelError
+      && error.code === "EVIDENCE_NOT_OBSERVATION",
+  );
+
+  const uncitedResidual: ResidualBinding = {
+    ...residual,
+    id: "uncited-but-byte-exact-audio",
+  };
+  const uncitedReceipt: FulfillmentRecorded = {
+    ...receipt,
+    residualIds: [uncitedResidual.id],
+  };
+  await assert.rejects(
+    () => verifyFulfillmentAgainstSubstrate(
+      need,
+      uncitedReceipt,
+      { projection: { target: projection, graph }, residualBindings: [uncitedResidual] },
+      store,
+    ),
+    (error: unknown) => error instanceof FulfillmentKernelError
+      && error.code === "RESIDUAL_NOT_IN_PROJECTION",
+  );
 });


### PR DESCRIPTION
## Purpose

Carry forward the non-duplicate proof obligations from draft PR #34 after PR #33 landed the reconciled fulfillment kernel first.

## What changed

- require a fulfillment-referenced projection to be an `observation`; `proposal` / `tension` may remain lawful projections, but they are not witness evidence for fulfillment;
- require each supplied exact WAV residual binding to be canonically addressed and actually cited by the referenced observation projection;
- keep the existing #33 composition path intact: shared identity -> immutable store -> projection/root closure -> real PCM residual verification -> externally addressed fulfillment receipt;
- strengthen the crossing characterization so the fulfillment receipt is a new derivative identity while the immutable WAV source bytes remain unchanged;
- add fail-closed coverage for a proposal masquerading as evidence and for a byte-exact residual that was never cited by the observation projection.

## Why this is a successor to #34

#34 was opened from the #32 base seconds before #33 merged and now conflicts because both introduce fulfillment code. The useful residue in #34 is stricter evidence binding, not a second fulfillment ontology. This PR ports only that residue onto current `main`.

## Boundary

No new canonicalizer, store, projection model, residual format, fulfillment ontology, UI work, or Haunted Toaster dependency.

Supersedes draft PR #34.