### PR TITLE
feat: prove Intent Stroke traversal decoding

### DIFF
--- a/docs/superpowers/plans/2026-08-17-intent-stroke-v0.1.md
+++ b/docs/superpowers/plans/2026-08-17-intent-stroke-v0.1.md
@@ -1,0 +1,70 @@
+# Intent Stroke / Swype NAV v0.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove that an approximate pointer stroke through a declared 2D conceptual layout can deterministically rank bounded traversal templates while preserving raw evidence, ambiguity, and non-authority.
+
+**Architecture:** Add one pure TranchNode projection module beside the existing projection primitives. Raw strokes and layouts are independently addressed with the existing `addressJson` floor; the decoder expands declared anchor routes into integer template samples, compares them with integer-only dynamic time warping plus endpoint cost, ranks every declared candidate deterministically, and fingerprints the non-authoritative decoding body. A JSON fixture supplies the first falsifiable specimen.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, existing TranchNode canonical addressing.
+
+## Global Constraints
+
+- Schema names are exactly `tranchnode/intent-stroke/v0.1`, `tranchnode/intent-stroke-layout/v0.1`, and `tranchnode/intent-stroke-decoding/v0.1`.
+- Decoding output carries `authority: "none"`.
+- Geometry and scoring are integer-only; no learned model or probabilistic confidence score.
+- Exact equal-cost leaders remain an explicit collision.
+- Candidate order must not affect normalized output.
+- Raw stroke and layout identities use the existing TranchNode / Project0 canonical-addressing implementation.
+- No Project0 ontology change, UI, topology mutation, admission, adoption, permission, Door, or Threshold.
+
+---
+
+### Task 1: Characterize the public contract with failing tests
+
+**Files:**
+- Create: `test/intent-stroke.test.ts`
+- Create: `fixtures/intent-stroke-v0.1.json`
+- Create: `src/intent-stroke.ts`
+
+**Interfaces:**
+- Consumes: `Addressed`, `Hash`, and `addressJson` from `src/residual.ts`.
+- Produces: `addressIntentStroke(...)`, `addressIntentStrokeFieldLayout(...)`, `decodeIntentStroke(...)`, `verifyIntentStrokeDecoding(...)` and their public v0.1 types.
+
+- [ ] **Step 1: Write failing tests** for canonical stroke/layout identity, deterministic ranking under input permutation, bounded perturbation, directional sensitivity, exact collision preservation, and stable validation reason codes.
+- [ ] **Step 2: Run `node --test --import tsx test/intent-stroke.test.ts`** and verify failure is caused by the missing module/API.
+- [ ] **Step 3: Commit the red characterization** if the execution surface supports intermediate commits; otherwise preserve the failing test evidence before implementation.
+
+### Task 2: Implement the minimum deterministic decoder
+
+**Files:**
+- Create: `src/intent-stroke.ts`
+- Modify: `test/intent-stroke.test.ts`
+
+**Interfaces:**
+- `addressIntentStroke(stroke: IntentStroke): Addressed<IntentStroke>` validates and addresses raw stroke evidence.
+- `addressIntentStrokeFieldLayout(layout: IntentStrokeFieldLayout): Addressed<IntentStrokeFieldLayout>` validates and addresses a fixed conceptual layout.
+- `decodeIntentStroke(request: IntentStrokeDecodeRequest): IntentStrokeDecoding` returns every declared template ordered by integer total cost and stable template id.
+- `verifyIntentStrokeDecoding(decoding: IntentStrokeDecoding): void` recomputes the fingerprint over the decoding body.
+
+- [ ] **Step 1: Validate bounded integer coordinates, strictly increasing stroke sequence, non-empty unique ids, layout/stroke identity, candidate references, and decoder configuration.**
+- [ ] **Step 2: Expand each declared anchor route with deterministic integer interpolation.**
+- [ ] **Step 3: Compute dynamic-time-warping path cost using Manhattan distance and checked safe-integer addition.**
+- [ ] **Step 4: Add checked endpoint cost, sort by `totalCost` then `templateId`, and mark every equal-cost leader in `ambiguity.leadingTemplateIds`.**
+- [ ] **Step 5: Fingerprint the body with `addressJson`; keep `authority: "none"`.**
+- [ ] **Step 6: Run the focused test until green.**
+
+### Task 3: Freeze the first specimen and verify the repository
+
+**Files:**
+- Create: `fixtures/intent-stroke-v0.1.json`
+- Modify: `test/intent-stroke.test.ts`
+
+**Interfaces:**
+- Fixture contains a fixed layout, three ordinary traversal templates, an intended approximate stroke, a perturbed stroke, a reversed stroke, and a deliberate collision pair.
+
+- [ ] **Step 1: Load the fixture as raw bytes and execute every specimen through the public decoder.**
+- [ ] **Step 2: Assert intended/perturbed leading traversal, reversed directional result, collision preservation, and fingerprint verification.**
+- [ ] **Step 3: Run `npm test`.**
+- [ ] **Step 4: Run `npm run check`.**
+- [ ] **Step 5: Review the final diff for ontology or authority creep before publishing the PR.**

--- a/fixtures/intent-stroke-v0.1.json
+++ b/fixtures/intent-stroke-v0.1.json
@@ -1,0 +1,72 @@
+{
+  "layout": {
+    "schema": "tranchnode/intent-stroke-layout/v0.1",
+    "anchors": [
+      { "id": "field-traversal", "x": 100, "y": 100 },
+      { "id": "metaphor-portal", "x": 300, "y": 180 },
+      { "id": "metaphor-portal-shadow", "x": 300, "y": 180 },
+      { "id": "tranchnode", "x": 520, "y": 320 },
+      { "id": "memory-terrain", "x": 100, "y": 360 },
+      { "id": "world-reentry", "x": 300, "y": 300 },
+      { "id": "stigmergic-field", "x": 300, "y": 520 },
+      { "id": "band-runtime", "x": 520, "y": 520 }
+    ]
+  },
+  "decoder": {
+    "id": "tranchnode/intent-stroke-dtw",
+    "version": "0.1",
+    "interpolationStepsPerSegment": 4,
+    "endpointPenaltyMultiplier": 3
+  },
+  "templates": [
+    {
+      "id": "field-to-tranchnode-via-portal",
+      "anchorIds": ["field-traversal", "metaphor-portal", "tranchnode"]
+    },
+    {
+      "id": "memory-to-tranchnode-via-reentry",
+      "anchorIds": ["memory-terrain", "world-reentry", "tranchnode"]
+    },
+    {
+      "id": "field-to-band-via-stigmergy",
+      "anchorIds": ["field-traversal", "stigmergic-field", "band-runtime"]
+    },
+    {
+      "id": "tranchnode-to-field-via-portal",
+      "anchorIds": ["tranchnode", "metaphor-portal", "field-traversal"]
+    }
+  ],
+  "collisionTemplates": [
+    {
+      "id": "portal-route-a",
+      "anchorIds": ["field-traversal", "metaphor-portal", "tranchnode"]
+    },
+    {
+      "id": "portal-route-b",
+      "anchorIds": ["field-traversal", "metaphor-portal-shadow", "tranchnode"]
+    }
+  ],
+  "strokes": {
+    "intended": [
+      { "sequence": 1, "x": 95, "y": 105 },
+      { "sequence": 2, "x": 180, "y": 130 },
+      { "sequence": 3, "x": 285, "y": 175 },
+      { "sequence": 4, "x": 390, "y": 235 },
+      { "sequence": 5, "x": 515, "y": 315 }
+    ],
+    "perturbed": [
+      { "sequence": 1, "x": 110, "y": 94 },
+      { "sequence": 2, "x": 190, "y": 145 },
+      { "sequence": 3, "x": 292, "y": 166 },
+      { "sequence": 4, "x": 405, "y": 246 },
+      { "sequence": 5, "x": 525, "y": 327 }
+    ],
+    "reversed": [
+      { "sequence": 1, "x": 515, "y": 315 },
+      { "sequence": 2, "x": 390, "y": 235 },
+      { "sequence": 3, "x": 285, "y": 175 },
+      { "sequence": 4, "x": 180, "y": 130 },
+      { "sequence": 5, "x": 95, "y": 105 }
+    ]
+  }
+}

--- a/src/intent-stroke.ts
+++ b/src/intent-stroke.ts
@@ -1,0 +1,499 @@
+import type { Addressed, Hash } from "./residual.js";
+import { addressJson } from "./residual.js";
+
+const MAX_COORDINATE = 1_000_000;
+const MAX_STROKE_POINTS = 512;
+const MAX_ANCHORS = 256;
+const MAX_TEMPLATES = 64;
+const MAX_TEMPLATE_ANCHORS = 32;
+const MAX_INTERPOLATION_STEPS = 32;
+const MAX_ENDPOINT_PENALTY_MULTIPLIER = 1_000;
+
+export type IntentStrokeErrorCode =
+  | "UNSUPPORTED_SCHEMA_VERSION"
+  | "INVALID_STROKE"
+  | "INVALID_COORDINATE"
+  | "INVALID_POINT_SEQUENCE"
+  | "INVALID_LAYOUT"
+  | "DUPLICATE_ANCHOR_ID"
+  | "STROKE_IDENTITY_MISMATCH"
+  | "LAYOUT_IDENTITY_MISMATCH"
+  | "LAYOUT_REF_MISMATCH"
+  | "INVALID_TEMPLATE"
+  | "DUPLICATE_TEMPLATE_ID"
+  | "MISSING_ANCHOR"
+  | "INVALID_DECODER_CONFIG"
+  | "ARITHMETIC_OVERFLOW"
+  | "FINGERPRINT_MISMATCH";
+
+export class IntentStrokeError extends Error {
+  constructor(
+    public readonly code: IntentStrokeErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "IntentStrokeError";
+  }
+}
+
+export interface IntentStrokePoint {
+  sequence: number;
+  x: number;
+  y: number;
+}
+
+export interface IntentStroke {
+  schema: "tranchnode/intent-stroke/v0.1";
+  fieldLayoutRef: Hash;
+  points: IntentStrokePoint[];
+}
+
+export interface IntentStrokeAnchor {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface IntentStrokeFieldLayout {
+  schema: "tranchnode/intent-stroke-layout/v0.1";
+  anchors: IntentStrokeAnchor[];
+}
+
+export interface TraversalTemplate {
+  id: string;
+  anchorIds: string[];
+}
+
+export interface IntentStrokeDecoderIdentity {
+  id: string;
+  version: string;
+  interpolationStepsPerSegment: number;
+  endpointPenaltyMultiplier: number;
+}
+
+export interface IntentStrokeCandidate {
+  templateId: string;
+  anchorIds: string[];
+  pathCost: number;
+  endpointCost: number;
+  totalCost: number;
+}
+
+export interface IntentStrokeDecoding {
+  schema: "tranchnode/intent-stroke-decoding/v0.1";
+  authority: "none";
+  strokeHash: Hash;
+  fieldLayoutRef: Hash;
+  decoder: IntentStrokeDecoderIdentity;
+  candidates: IntentStrokeCandidate[];
+  ambiguity: {
+    kind: "none" | "collision";
+    leadingTemplateIds: string[];
+  };
+  fingerprint: Hash;
+}
+
+export interface IntentStrokeDecodeRequest {
+  stroke: Addressed<IntentStroke>;
+  layout: Addressed<IntentStrokeFieldLayout>;
+  templates: TraversalTemplate[];
+  decoder: IntentStrokeDecoderIdentity;
+}
+
+interface GridPoint {
+  x: number;
+  y: number;
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function isNonEmptyText(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function isCoordinate(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0 && value <= MAX_COORDINATE;
+}
+
+function checkedAdd(left: number, right: number): number {
+  const result = left + right;
+  if (!Number.isSafeInteger(result)) {
+    throw new IntentStrokeError(
+      "ARITHMETIC_OVERFLOW",
+      "intent stroke arithmetic exceeded the safe integer range",
+    );
+  }
+  return result;
+}
+
+function checkedMultiply(left: number, right: number): number {
+  const result = left * right;
+  if (!Number.isSafeInteger(result)) {
+    throw new IntentStrokeError(
+      "ARITHMETIC_OVERFLOW",
+      "intent stroke arithmetic exceeded the safe integer range",
+    );
+  }
+  return result;
+}
+
+function validatePoint(point: IntentStrokePoint): void {
+  if (!isCoordinate(point.x) || !isCoordinate(point.y)) {
+    throw new IntentStrokeError(
+      "INVALID_COORDINATE",
+      `stroke coordinate must be an integer from 0 through ${MAX_COORDINATE}`,
+    );
+  }
+  if (!Number.isSafeInteger(point.sequence) || point.sequence < 0) {
+    throw new IntentStrokeError(
+      "INVALID_POINT_SEQUENCE",
+      "stroke point sequence must be a non-negative safe integer",
+    );
+  }
+}
+
+function validateStroke(stroke: IntentStroke): void {
+  if (stroke.schema !== "tranchnode/intent-stroke/v0.1") {
+    throw new IntentStrokeError(
+      "UNSUPPORTED_SCHEMA_VERSION",
+      `unsupported stroke schema ${String(stroke.schema)}`,
+    );
+  }
+  if (stroke.points.length < 2 || stroke.points.length > MAX_STROKE_POINTS) {
+    throw new IntentStrokeError(
+      "INVALID_STROKE",
+      `stroke must contain from 2 through ${MAX_STROKE_POINTS} points`,
+    );
+  }
+
+  let previousSequence = -1;
+  for (const point of stroke.points) {
+    validatePoint(point);
+    if (point.sequence <= previousSequence) {
+      throw new IntentStrokeError(
+        "INVALID_POINT_SEQUENCE",
+        "stroke point sequence must increase strictly",
+      );
+    }
+    previousSequence = point.sequence;
+  }
+}
+
+function validateLayout(layout: IntentStrokeFieldLayout): Map<string, IntentStrokeAnchor> {
+  if (layout.schema !== "tranchnode/intent-stroke-layout/v0.1") {
+    throw new IntentStrokeError(
+      "UNSUPPORTED_SCHEMA_VERSION",
+      `unsupported layout schema ${String(layout.schema)}`,
+    );
+  }
+  if (layout.anchors.length < 2 || layout.anchors.length > MAX_ANCHORS) {
+    throw new IntentStrokeError(
+      "INVALID_LAYOUT",
+      `layout must contain from 2 through ${MAX_ANCHORS} anchors`,
+    );
+  }
+
+  const anchors = new Map<string, IntentStrokeAnchor>();
+  for (const anchor of layout.anchors) {
+    if (!isNonEmptyText(anchor.id)) {
+      throw new IntentStrokeError("INVALID_LAYOUT", "anchor id must be non-empty");
+    }
+    if (!isCoordinate(anchor.x) || !isCoordinate(anchor.y)) {
+      throw new IntentStrokeError(
+        "INVALID_COORDINATE",
+        `anchor coordinate must be an integer from 0 through ${MAX_COORDINATE}`,
+      );
+    }
+    if (anchors.has(anchor.id)) {
+      throw new IntentStrokeError(
+        "DUPLICATE_ANCHOR_ID",
+        `layout repeats anchor id ${anchor.id}`,
+      );
+    }
+    anchors.set(anchor.id, anchor);
+  }
+  return anchors;
+}
+
+function validateDecoder(decoder: IntentStrokeDecoderIdentity): void {
+  if (!isNonEmptyText(decoder.id) || !isNonEmptyText(decoder.version)) {
+    throw new IntentStrokeError(
+      "INVALID_DECODER_CONFIG",
+      "decoder id and version must be non-empty",
+    );
+  }
+  if (
+    !Number.isSafeInteger(decoder.interpolationStepsPerSegment)
+    || decoder.interpolationStepsPerSegment < 1
+    || decoder.interpolationStepsPerSegment > MAX_INTERPOLATION_STEPS
+  ) {
+    throw new IntentStrokeError(
+      "INVALID_DECODER_CONFIG",
+      `interpolationStepsPerSegment must be an integer from 1 through ${MAX_INTERPOLATION_STEPS}`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(decoder.endpointPenaltyMultiplier)
+    || decoder.endpointPenaltyMultiplier < 0
+    || decoder.endpointPenaltyMultiplier > MAX_ENDPOINT_PENALTY_MULTIPLIER
+  ) {
+    throw new IntentStrokeError(
+      "INVALID_DECODER_CONFIG",
+      `endpointPenaltyMultiplier must be an integer from 0 through ${MAX_ENDPOINT_PENALTY_MULTIPLIER}`,
+    );
+  }
+}
+
+function validateTemplates(
+  templates: TraversalTemplate[],
+  anchors: ReadonlyMap<string, IntentStrokeAnchor>,
+): TraversalTemplate[] {
+  if (templates.length < 1 || templates.length > MAX_TEMPLATES) {
+    throw new IntentStrokeError(
+      "INVALID_TEMPLATE",
+      `decoder requires from 1 through ${MAX_TEMPLATES} traversal templates`,
+    );
+  }
+
+  const ids = new Set<string>();
+  const normalized: TraversalTemplate[] = [];
+  for (const template of templates) {
+    if (!isNonEmptyText(template.id)) {
+      throw new IntentStrokeError("INVALID_TEMPLATE", "template id must be non-empty");
+    }
+    if (ids.has(template.id)) {
+      throw new IntentStrokeError(
+        "DUPLICATE_TEMPLATE_ID",
+        `decoder repeats template id ${template.id}`,
+      );
+    }
+    ids.add(template.id);
+
+    if (template.anchorIds.length < 2 || template.anchorIds.length > MAX_TEMPLATE_ANCHORS) {
+      throw new IntentStrokeError(
+        "INVALID_TEMPLATE",
+        `template ${template.id} must contain from 2 through ${MAX_TEMPLATE_ANCHORS} anchors`,
+      );
+    }
+
+    for (const anchorId of template.anchorIds) {
+      if (!isNonEmptyText(anchorId)) {
+        throw new IntentStrokeError(
+          "INVALID_TEMPLATE",
+          `template ${template.id} contains an empty anchor id`,
+        );
+      }
+      if (!anchors.has(anchorId)) {
+        throw new IntentStrokeError(
+          "MISSING_ANCHOR",
+          `template ${template.id} references missing anchor ${anchorId}`,
+        );
+      }
+    }
+
+    normalized.push({
+      id: template.id,
+      anchorIds: [...template.anchorIds],
+    });
+  }
+  return normalized;
+}
+
+function assertAddressIdentity<T>(
+  addressed: Addressed<T>,
+  mismatchCode: "STROKE_IDENTITY_MISMATCH" | "LAYOUT_IDENTITY_MISMATCH",
+): void {
+  const recomputed = addressJson(addressed.value).hash;
+  if (recomputed !== addressed.hash) {
+    throw new IntentStrokeError(
+      mismatchCode,
+      `body hashes to ${recomputed}, not declared identity ${addressed.hash}`,
+    );
+  }
+}
+
+function interpolateCoordinate(start: number, end: number, step: number, steps: number): number {
+  const weighted = checkedAdd(
+    checkedMultiply(start, steps - step),
+    checkedMultiply(end, step),
+  );
+  return Math.floor(checkedAdd(weighted, Math.floor(steps / 2)) / steps);
+}
+
+function expandTemplate(
+  template: TraversalTemplate,
+  anchors: ReadonlyMap<string, IntentStrokeAnchor>,
+  steps: number,
+): GridPoint[] {
+  const expanded: GridPoint[] = [];
+
+  for (let index = 0; index < template.anchorIds.length - 1; index += 1) {
+    const startId = template.anchorIds[index];
+    const endId = template.anchorIds[index + 1];
+    if (startId === undefined || endId === undefined) {
+      throw new IntentStrokeError("INVALID_TEMPLATE", `template ${template.id} is malformed`);
+    }
+    const start = anchors.get(startId);
+    const end = anchors.get(endId);
+    if (!start || !end) {
+      throw new IntentStrokeError(
+        "MISSING_ANCHOR",
+        `template ${template.id} references a missing anchor`,
+      );
+    }
+
+    if (index === 0) expanded.push({ x: start.x, y: start.y });
+    for (let step = 1; step <= steps; step += 1) {
+      expanded.push({
+        x: interpolateCoordinate(start.x, end.x, step, steps),
+        y: interpolateCoordinate(start.y, end.y, step, steps),
+      });
+    }
+  }
+
+  return expanded;
+}
+
+function manhattan(left: GridPoint, right: GridPoint): number {
+  return checkedAdd(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+function dynamicTimeWarping(stroke: readonly GridPoint[], template: readonly GridPoint[]): number {
+  let previous = new Array<number>(template.length + 1).fill(Number.MAX_SAFE_INTEGER);
+  previous[0] = 0;
+
+  for (const strokePoint of stroke) {
+    const current = new Array<number>(template.length + 1).fill(Number.MAX_SAFE_INTEGER);
+    for (let column = 1; column <= template.length; column += 1) {
+      const templatePoint = template[column - 1];
+      if (!templatePoint) {
+        throw new IntentStrokeError("INVALID_TEMPLATE", "expanded template is malformed");
+      }
+      const priorSameColumn = previous[column] ?? Number.MAX_SAFE_INTEGER;
+      const priorCurrentRow = current[column - 1] ?? Number.MAX_SAFE_INTEGER;
+      const priorDiagonal = previous[column - 1] ?? Number.MAX_SAFE_INTEGER;
+      const prior = Math.min(priorSameColumn, priorCurrentRow, priorDiagonal);
+      current[column] = checkedAdd(prior, manhattan(strokePoint, templatePoint));
+    }
+    previous = current;
+  }
+
+  const result = previous[template.length];
+  if (result === undefined || !Number.isSafeInteger(result)) {
+    throw new IntentStrokeError("ARITHMETIC_OVERFLOW", "unable to compute a safe path cost");
+  }
+  return result;
+}
+
+function scoreTemplate(
+  stroke: IntentStroke,
+  template: TraversalTemplate,
+  anchors: ReadonlyMap<string, IntentStrokeAnchor>,
+  decoder: IntentStrokeDecoderIdentity,
+): IntentStrokeCandidate {
+  const expanded = expandTemplate(template, anchors, decoder.interpolationStepsPerSegment);
+  const strokePoints: GridPoint[] = stroke.points.map((point) => ({ x: point.x, y: point.y }));
+  const firstStroke = strokePoints[0];
+  const lastStroke = strokePoints[strokePoints.length - 1];
+  const firstTemplate = expanded[0];
+  const lastTemplate = expanded[expanded.length - 1];
+  if (!firstStroke || !lastStroke || !firstTemplate || !lastTemplate) {
+    throw new IntentStrokeError("INVALID_STROKE", "stroke or template has no endpoints");
+  }
+
+  const pathCost = dynamicTimeWarping(strokePoints, expanded);
+  const endpointDistance = checkedAdd(
+    manhattan(firstStroke, firstTemplate),
+    manhattan(lastStroke, lastTemplate),
+  );
+  const endpointCost = checkedMultiply(endpointDistance, decoder.endpointPenaltyMultiplier);
+  const totalCost = checkedAdd(pathCost, endpointCost);
+
+  return {
+    templateId: template.id,
+    anchorIds: [...template.anchorIds],
+    pathCost,
+    endpointCost,
+    totalCost,
+  };
+}
+
+export function addressIntentStroke(stroke: IntentStroke): Addressed<IntentStroke> {
+  validateStroke(stroke);
+  return addressJson(stroke);
+}
+
+export function addressIntentStrokeFieldLayout(
+  layout: IntentStrokeFieldLayout,
+): Addressed<IntentStrokeFieldLayout> {
+  validateLayout(layout);
+  return addressJson(layout);
+}
+
+export function decodeIntentStroke(request: IntentStrokeDecodeRequest): IntentStrokeDecoding {
+  validateStroke(request.stroke.value);
+  const anchors = validateLayout(request.layout.value);
+  validateDecoder(request.decoder);
+  assertAddressIdentity(request.stroke, "STROKE_IDENTITY_MISMATCH");
+  assertAddressIdentity(request.layout, "LAYOUT_IDENTITY_MISMATCH");
+
+  if (request.stroke.value.fieldLayoutRef !== request.layout.hash) {
+    throw new IntentStrokeError(
+      "LAYOUT_REF_MISMATCH",
+      `stroke declares layout ${request.stroke.value.fieldLayoutRef}, received ${request.layout.hash}`,
+    );
+  }
+
+  const templates = validateTemplates(request.templates, anchors);
+  const candidates = templates.map((template) =>
+    scoreTemplate(request.stroke.value, template, anchors, request.decoder));
+  candidates.sort((left, right) =>
+    left.totalCost - right.totalCost || compareText(left.templateId, right.templateId));
+
+  const leadingCost = candidates[0]?.totalCost;
+  if (leadingCost === undefined) {
+    throw new IntentStrokeError("INVALID_TEMPLATE", "decoder has no candidates");
+  }
+  const leadingTemplateIds = candidates
+    .filter((candidate) => candidate.totalCost === leadingCost)
+    .map((candidate) => candidate.templateId)
+    .sort(compareText);
+
+  const body: Omit<IntentStrokeDecoding, "fingerprint"> = {
+    schema: "tranchnode/intent-stroke-decoding/v0.1",
+    authority: "none",
+    strokeHash: request.stroke.hash,
+    fieldLayoutRef: request.layout.hash,
+    decoder: {
+      id: request.decoder.id,
+      version: request.decoder.version,
+      interpolationStepsPerSegment: request.decoder.interpolationStepsPerSegment,
+      endpointPenaltyMultiplier: request.decoder.endpointPenaltyMultiplier,
+    },
+    candidates,
+    ambiguity: {
+      kind: leadingTemplateIds.length > 1 ? "collision" : "none",
+      leadingTemplateIds,
+    },
+  };
+
+  return {
+    ...body,
+    fingerprint: addressJson(body).hash,
+  };
+}
+
+export function verifyIntentStrokeDecoding(decoding: IntentStrokeDecoding): void {
+  const { fingerprint, ...body } = decoding;
+  const expected = addressJson(body).hash;
+  if (expected !== fingerprint) {
+    throw new IntentStrokeError(
+      "FINGERPRINT_MISMATCH",
+      `expected ${expected}, received ${fingerprint}`,
+    );
+  }
+}

--- a/test/intent-stroke.test.ts
+++ b/test/intent-stroke.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import type { Hash } from "../src/residual.js";
+import {
+  IntentStrokeError,
+  addressIntentStroke,
+  addressIntentStrokeFieldLayout,
+  decodeIntentStroke,
+  verifyIntentStrokeDecoding,
+  type IntentStroke,
+  type IntentStrokeDecoderIdentity,
+  type IntentStrokeFieldLayout,
+  type IntentStrokePoint,
+  type TraversalTemplate,
+} from "../src/intent-stroke.js";
+
+interface Fixture {
+  layout: IntentStrokeFieldLayout;
+  decoder: IntentStrokeDecoderIdentity;
+  templates: TraversalTemplate[];
+  collisionTemplates: TraversalTemplate[];
+  strokes: {
+    intended: IntentStrokePoint[];
+    perturbed: IntentStrokePoint[];
+    reversed: IntentStrokePoint[];
+  };
+}
+
+const fixture = JSON.parse(
+  await readFile(new URL("../fixtures/intent-stroke-v0.1.json", import.meta.url), "utf8"),
+) as Fixture;
+
+function expectCode(fn: () => unknown, code: IntentStrokeError["code"]): void {
+  assert.throws(
+    fn,
+    (error: unknown) => error instanceof IntentStrokeError && error.code === code,
+  );
+}
+
+function makeStroke(points: IntentStrokePoint[], fieldLayoutRef?: Hash): IntentStroke {
+  const layoutRef = fieldLayoutRef ?? addressIntentStrokeFieldLayout(fixture.layout).hash;
+  return {
+    schema: "tranchnode/intent-stroke/v0.1",
+    fieldLayoutRef: layoutRef,
+    points,
+  };
+}
+
+function decode(
+  points: IntentStrokePoint[],
+  templates: TraversalTemplate[] = fixture.templates,
+) {
+  const layout = addressIntentStrokeFieldLayout(fixture.layout);
+  const stroke = addressIntentStroke(makeStroke(points, layout.hash));
+  return decodeIntentStroke({
+    stroke,
+    layout,
+    templates,
+    decoder: fixture.decoder,
+  });
+}
+
+test("raw stroke and field layout have stable independent identities", () => {
+  const firstLayout = addressIntentStrokeFieldLayout(fixture.layout);
+  const secondLayout = addressIntentStrokeFieldLayout(fixture.layout);
+  assert.equal(firstLayout.hash, secondLayout.hash);
+
+  const firstStroke = addressIntentStroke(makeStroke(fixture.strokes.intended, firstLayout.hash));
+  const secondStroke = addressIntentStroke(makeStroke(fixture.strokes.intended, firstLayout.hash));
+  assert.equal(firstStroke.hash, secondStroke.hash);
+  assert.notEqual(firstStroke.hash, firstLayout.hash);
+});
+
+test("approximate stroke ranks the intended declared traversal first", () => {
+  const decoding = decode(fixture.strokes.intended);
+  assert.equal(decoding.authority, "none");
+  assert.equal(decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+  assert.equal(decoding.ambiguity.kind, "none");
+  assert.deepEqual(decoding.ambiguity.leadingTemplateIds, ["field-to-tranchnode-via-portal"]);
+  verifyIntentStrokeDecoding(decoding);
+});
+
+test("candidate input order does not alter normalized decoding", () => {
+  const first = decode(fixture.strokes.intended, fixture.templates);
+  const second = decode(fixture.strokes.intended, [...fixture.templates].reverse());
+  assert.deepEqual(first, second);
+});
+
+test("bounded perturbation preserves the same leading traversal", () => {
+  const decoding = decode(fixture.strokes.perturbed);
+  assert.equal(decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+});
+
+test("stroke direction materially affects ranking", () => {
+  const forward = decode(fixture.strokes.intended);
+  const reversed = decode(fixture.strokes.reversed);
+  assert.equal(forward.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+  assert.equal(reversed.candidates[0]?.templateId, "tranchnode-to-field-via-portal");
+  assert.notEqual(forward.candidates[0]?.templateId, reversed.candidates[0]?.templateId);
+});
+
+test("exact equal-cost leaders remain an explicit unresolved collision", () => {
+  const decoding = decode(fixture.strokes.intended, fixture.collisionTemplates);
+  assert.equal(decoding.ambiguity.kind, "collision");
+  assert.deepEqual(decoding.ambiguity.leadingTemplateIds, ["portal-route-a", "portal-route-b"]);
+  assert.equal(decoding.candidates[0]?.totalCost, decoding.candidates[1]?.totalCost);
+});
+
+test("validation fails closed with stable reason codes", () => {
+  expectCode(
+    () => addressIntentStrokeFieldLayout({
+      ...fixture.layout,
+      anchors: [fixture.layout.anchors[0]!, fixture.layout.anchors[0]!],
+    }),
+    "DUPLICATE_ANCHOR_ID",
+  );
+
+  expectCode(
+    () => addressIntentStrokeFieldLayout({
+      ...fixture.layout,
+      anchors: [{ id: "bad", x: -1, y: 0 }, ...fixture.layout.anchors.slice(1)],
+    }),
+    "INVALID_COORDINATE",
+  );
+
+  const layout = addressIntentStrokeFieldLayout(fixture.layout);
+  expectCode(
+    () => addressIntentStroke(makeStroke([
+      { sequence: 1, x: 100, y: 100 },
+      { sequence: 1, x: 200, y: 150 },
+    ], layout.hash)),
+    "INVALID_POINT_SEQUENCE",
+  );
+
+  const fakeRef = (`sha256:${"0".repeat(64)}`) as Hash;
+  const mismatchedStroke = addressIntentStroke(makeStroke(fixture.strokes.intended, fakeRef));
+  expectCode(
+    () => decodeIntentStroke({
+      stroke: mismatchedStroke,
+      layout,
+      templates: fixture.templates,
+      decoder: fixture.decoder,
+    }),
+    "LAYOUT_REF_MISMATCH",
+  );
+
+  const stroke = addressIntentStroke(makeStroke(fixture.strokes.intended, layout.hash));
+  expectCode(
+    () => decodeIntentStroke({
+      stroke,
+      layout,
+      templates: [{ id: "missing", anchorIds: ["field-traversal", "does-not-exist"] }],
+      decoder: fixture.decoder,
+    }),
+    "MISSING_ANCHOR",
+  );
+
+  expectCode(
+    () => decodeIntentStroke({
+      stroke,
+      layout,
+      templates: [fixture.templates[0]!, { ...fixture.templates[1]!, id: fixture.templates[0]!.id }],
+      decoder: fixture.decoder,
+    }),
+    "DUPLICATE_TEMPLATE_ID",
+  );
+
+  expectCode(
+    () => decodeIntentStroke({
+      stroke,
+      layout,
+      templates: fixture.templates,
+      decoder: { ...fixture.decoder, interpolationStepsPerSegment: 0 },
+    }),
+    "INVALID_DECODER_CONFIG",
+  );
+});
+
+test("tampered decoding fingerprint is rejected", () => {
+  const decoding = decode(fixture.strokes.intended);
+  const tampered = {
+    ...decoding,
+    fingerprint: (`sha256:${"f".repeat(64)}`) as Hash,
+  };
+  expectCode(() => verifyIntentStrokeDecoding(tampered), "FINGERPRINT_MISMATCH");
+});


### PR DESCRIPTION
## Summary

Implements TranchNode Intent Stroke / Swype NAV v0.1: deterministic decoding of an approximate pointer trajectory against explicitly declared traversal templates while preserving raw stroke evidence, exact ambiguity, and non-authority.

The bounded claim is:

> Traversal itself can be input.

## What landed

- independently addressed raw strokes and fixed field layouts using the existing TranchNode / Project0 `addressJson` floor;
- integer-only route expansion and dynamic-time-warping comparison using Manhattan distance;
- explicit endpoint cost and stable candidate ordering;
- every declared traversal candidate retained in the decoding;
- exact equal-cost leaders surfaced as an unresolved collision instead of a forced winner;
- decoding body carries `authority: "none"` and a canonical fingerprint;
- fixture-backed intended, perturbed, reversed, and collision specimens;
- fail-closed validation for malformed coordinates/sequences, duplicate ids, missing anchors, mismatched layout refs, invalid decoder configuration, and fingerprint tampering.

## Governing distinctions

```text
crossed anchor != selected anchor
near anchor != asserted relation
ranked candidate != accepted traversal
accepted traversal != authority
collision != decoder failure
```

## TDD / verification evidence

- RED: GitHub Actions run `31990649313` failed on head `5eb88fe11ae4abab33e27dc5356d0fdada6276c8` while `src/intent-stroke.ts` was intentionally absent.
- GREEN: GitHub Actions run `31990749220` completed successfully on exact implementation head `526a3af023748f61dd67d220258ede4dfeee23a1`.
- The successful job ran repository-native `npm run check`, which performs `tsc --noEmit` and the complete Node test suite.
- The sole successful-run annotation is an unrelated GitHub Actions warning that `actions/checkout@v4` and `actions/setup-node@v4` still target deprecated Node 20 internally; the runner forces them onto Node 24. This PR does not modify workflow files.

## Scope boundaries

- no Project0 ontology change;
- no UI or touch surface;
- no free-form graph search;
- no embeddings, LLM inference, learned gesture model, or probabilistic confidence score;
- no automatic admission/adoption;
- no topology mutation, Door, Threshold, permission, or recommendation system;
- no Stigmergic Field or Haunted Toaster coupling yet.

## Environment note

This ChatGPT host has no local GitHub network route and no installed `riqor` CLI, so a local Riqor trace cannot be honestly produced. Riqor's evidence/reviewer discipline is being applied against fresh connected-repository evidence, with GitHub Actions on the exact head serving as the executable repository gate.

Closes #40