### PR TITLE
Expose Intent Stroke local process port

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit && node --test --import tsx test/**/*.test.ts",
-    "test": "node --test --import tsx test/**/*.test.ts"
+    "test": "node --test --import tsx test/**/*.test.ts",
+    "intent-stroke:stdio": "node --import tsx scripts/intent-stroke-stdio.ts"
   },
   "dependencies": {
     "canonicalize": "^2.1.0"

--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -1,0 +1,103 @@
+import {
+  IntentStrokeError,
+  addressIntentStroke,
+  addressIntentStrokeFieldLayout,
+  decodeIntentStroke,
+  type IntentStroke,
+  type IntentStrokeDecoderIdentity,
+  type IntentStrokeFieldLayout,
+  type TraversalTemplate,
+} from "../src/intent-stroke.js";
+
+interface IntentStrokeProcessRequest {
+  schema: "tranchnode.intent-stroke-process/v0.1";
+  operation: "decode";
+  stroke: IntentStroke;
+  layout: IntentStrokeFieldLayout;
+  templates: TraversalTemplate[];
+  decoder: IntentStrokeDecoderIdentity;
+}
+
+interface ProcessErrorResult {
+  schema: "tranchnode.intent-stroke-process-result/v0.1";
+  status: "error";
+  code: string;
+  message: string;
+}
+
+function fail(code: string, message: string): never {
+  const result: ProcessErrorResult = {
+    schema: "tranchnode.intent-stroke-process-result/v0.1",
+    status: "error",
+    code,
+    message,
+  };
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exitCode = 1;
+  throw new Error("__PROCESS_RESULT_WRITTEN__");
+}
+
+function parseRequest(input: string): IntentStrokeProcessRequest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    fail("INVALID_JSON", "stdin must contain one JSON request");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("INVALID_PROCESS_REQUEST", "process request must be a JSON object");
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (record.schema !== "tranchnode.intent-stroke-process/v0.1") {
+    fail("UNSUPPORTED_PROCESS_SCHEMA", `unsupported process schema ${String(record.schema)}`);
+  }
+  if (record.operation !== "decode") {
+    fail("UNSUPPORTED_PROCESS_OPERATION", `unsupported process operation ${String(record.operation)}`);
+  }
+
+  return parsed as IntentStrokeProcessRequest;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<void> {
+  const request = parseRequest(await readStdin());
+  const layout = addressIntentStrokeFieldLayout(request.layout);
+  const stroke = addressIntentStroke(request.stroke);
+  const decoding = decodeIntentStroke({
+    stroke,
+    layout,
+    templates: request.templates,
+    decoder: request.decoder,
+  });
+
+  process.stdout.write(`${JSON.stringify({
+    schema: "tranchnode.intent-stroke-process-result/v0.1",
+    status: "ok",
+    decoding,
+  })}\n`);
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof Error && error.message === "__PROCESS_RESULT_WRITTEN__") {
+    return;
+  }
+
+  const code = error instanceof IntentStrokeError ? error.code : "PROCESS_FAILURE";
+  const message = error instanceof Error ? error.message : String(error);
+  process.stdout.write(`${JSON.stringify({
+    schema: "tranchnode.intent-stroke-process-result/v0.1",
+    status: "error",
+    code,
+    message,
+  })}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -9,6 +9,8 @@ import {
   type TraversalTemplate,
 } from "../src/intent-stroke.js";
 
+const MAX_STDIN_BYTES = 1_048_576;
+
 interface IntentStrokeProcessRequest {
   schema: "tranchnode.intent-stroke-process/v0.1";
   operation: "decode";
@@ -62,8 +64,14 @@ function parseRequest(input: string): IntentStrokeProcessRequest {
 
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
+  let total = 0;
   for await (const chunk of process.stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.byteLength;
+    if (total > MAX_STDIN_BYTES) {
+      fail("PROCESS_INPUT_TOO_LARGE", "stdin exceeds the one MiB process limit");
+    }
+    chunks.push(buffer);
   }
   return Buffer.concat(chunks).toString("utf8");
 }

--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -11,7 +11,13 @@ import {
 
 const MAX_STDIN_BYTES = 1_048_576;
 
-interface IntentStrokeProcessRequest {
+interface AddressLayoutProcessRequest {
+  schema: "tranchnode.intent-stroke-process/v0.1";
+  operation: "address-layout";
+  layout: IntentStrokeFieldLayout;
+}
+
+interface DecodeProcessRequest {
   schema: "tranchnode.intent-stroke-process/v0.1";
   operation: "decode";
   stroke: IntentStroke;
@@ -19,6 +25,8 @@ interface IntentStrokeProcessRequest {
   templates: TraversalTemplate[];
   decoder: IntentStrokeDecoderIdentity;
 }
+
+type IntentStrokeProcessRequest = AddressLayoutProcessRequest | DecodeProcessRequest;
 
 interface ProcessErrorResult {
   schema: "tranchnode.intent-stroke-process-result/v0.1";
@@ -55,7 +63,7 @@ function parseRequest(input: string): IntentStrokeProcessRequest {
   if (record.schema !== "tranchnode.intent-stroke-process/v0.1") {
     fail("UNSUPPORTED_PROCESS_SCHEMA", `unsupported process schema ${String(record.schema)}`);
   }
-  if (record.operation !== "decode") {
+  if (record.operation !== "address-layout" && record.operation !== "decode") {
     fail("UNSUPPORTED_PROCESS_OPERATION", `unsupported process operation ${String(record.operation)}`);
   }
 
@@ -78,6 +86,18 @@ async function readStdin(): Promise<string> {
 
 async function main(): Promise<void> {
   const request = parseRequest(await readStdin());
+
+  if (request.operation === "address-layout") {
+    const addressed = addressIntentStrokeFieldLayout(request.layout);
+    process.stdout.write(`${JSON.stringify({
+      schema: "tranchnode.intent-stroke-process-result/v0.1",
+      status: "ok",
+      operation: "address-layout",
+      addressed,
+    })}\n`);
+    return;
+  }
+
   const layout = addressIntentStrokeFieldLayout(request.layout);
   const stroke = addressIntentStroke(request.stroke);
   const decoding = decodeIntentStroke({
@@ -90,6 +110,7 @@ async function main(): Promise<void> {
   process.stdout.write(`${JSON.stringify({
     schema: "tranchnode.intent-stroke-process-result/v0.1",
     status: "ok",
+    operation: "decode",
     decoding,
   })}\n`);
 }

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -9,15 +9,24 @@ import {
   type IntentStrokeFieldLayout,
 } from "../src/intent-stroke.js";
 
+const layout: IntentStrokeFieldLayout = {
+  schema: "tranchnode/intent-stroke-layout/v0.1",
+  anchors: [
+    { id: "garden", x: 0, y: 0 },
+    { id: "corpus", x: 100, y: 0 },
+    { id: "upper-room", x: 0, y: 100 },
+  ],
+};
+
+function run(request: unknown) {
+  return spawnSync(
+    process.execPath,
+    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
+    { input: JSON.stringify(request), encoding: "utf8" },
+  );
+}
+
 function makeRequest() {
-  const layout: IntentStrokeFieldLayout = {
-    schema: "tranchnode/intent-stroke-layout/v0.1",
-    anchors: [
-      { id: "garden", x: 0, y: 0 },
-      { id: "corpus", x: 100, y: 0 },
-      { id: "upper-room", x: 0, y: 100 },
-    ],
-  };
   const addressedLayout = addressIntentStrokeFieldLayout(layout);
   const stroke: IntentStroke = {
     schema: "tranchnode/intent-stroke/v0.1",
@@ -46,30 +55,37 @@ function makeRequest() {
   };
 }
 
-test("stdio adapter returns the native non-authoritative decoding", () => {
-  const child = spawnSync(
-    process.execPath,
-    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
-    { input: JSON.stringify(makeRequest()), encoding: "utf8" },
-  );
+test("stdio adapter returns the native layout address without external canonicalization", () => {
+  const native = addressIntentStrokeFieldLayout(layout);
+  const child = run({
+    schema: "tranchnode.intent-stroke-process/v0.1",
+    operation: "address-layout",
+    layout,
+  });
 
   assert.equal(child.status, 0, child.stderr);
   const body = JSON.parse(child.stdout);
   assert.equal(body.schema, "tranchnode.intent-stroke-process-result/v0.1");
   assert.equal(body.status, "ok");
+  assert.equal(body.operation, "address-layout");
+  assert.equal(body.addressed.hash, native.hash);
+  assert.deepEqual(body.addressed.value, native.value);
+});
+
+test("stdio adapter returns the native non-authoritative decoding", () => {
+  const child = run(makeRequest());
+
+  assert.equal(child.status, 0, child.stderr);
+  const body = JSON.parse(child.stdout);
+  assert.equal(body.schema, "tranchnode.intent-stroke-process-result/v0.1");
+  assert.equal(body.status, "ok");
+  assert.equal(body.operation, "decode");
   assert.equal(body.decoding.authority, "none");
   assert.equal(body.decoding.candidates[0].templateId, "garden-to-corpus");
 });
 
 test("stdio adapter fails closed on an unsupported process schema", () => {
-  const child = spawnSync(
-    process.execPath,
-    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
-    {
-      input: JSON.stringify({ ...makeRequest(), schema: "tranchnode.intent-stroke-process/v9" }),
-      encoding: "utf8",
-    },
-  );
+  const child = run({ ...makeRequest(), schema: "tranchnode.intent-stroke-process/v9" });
 
   assert.notEqual(child.status, 0);
   const body = JSON.parse(child.stdout);
@@ -77,15 +93,21 @@ test("stdio adapter fails closed on an unsupported process schema", () => {
   assert.equal(body.code, "UNSUPPORTED_PROCESS_SCHEMA");
 });
 
+test("stdio adapter fails closed on an unsupported operation", () => {
+  const child = run({
+    schema: "tranchnode.intent-stroke-process/v0.1",
+    operation: "cross-door",
+    layout,
+  });
+
+  assert.notEqual(child.status, 0);
+  const body = JSON.parse(child.stdout);
+  assert.equal(body.status, "error");
+  assert.equal(body.code, "UNSUPPORTED_PROCESS_OPERATION");
+});
+
 test("stdio adapter rejects input larger than one MiB", () => {
-  const child = spawnSync(
-    process.execPath,
-    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
-    {
-      input: JSON.stringify({ ...makeRequest(), padding: "x".repeat(1_048_576) }),
-      encoding: "utf8",
-    },
-  );
+  const child = run({ ...makeRequest(), padding: "x".repeat(1_048_576) });
 
   assert.notEqual(child.status, 0);
   const body = JSON.parse(child.stdout);

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  addressIntentStroke,
+  addressIntentStrokeFieldLayout,
+  type IntentStroke,
+  type IntentStrokeFieldLayout,
+} from "../src/intent-stroke.js";
+
+function makeRequest() {
+  const layout: IntentStrokeFieldLayout = {
+    schema: "tranchnode/intent-stroke-layout/v0.1",
+    anchors: [
+      { id: "garden", x: 0, y: 0 },
+      { id: "corpus", x: 100, y: 0 },
+      { id: "upper-room", x: 0, y: 100 },
+    ],
+  };
+  const addressedLayout = addressIntentStrokeFieldLayout(layout);
+  const stroke: IntentStroke = {
+    schema: "tranchnode/intent-stroke/v0.1",
+    fieldLayoutRef: addressedLayout.hash,
+    points: [
+      { sequence: 0, x: 0, y: 0 },
+      { sequence: 1, x: 100, y: 0 },
+    ],
+  };
+  const addressedStroke = addressIntentStroke(stroke);
+  return {
+    schema: "tranchnode.intent-stroke-process/v0.1",
+    operation: "decode",
+    stroke: addressedStroke.value,
+    layout: addressedLayout.value,
+    templates: [
+      { id: "garden-to-corpus", anchorIds: ["garden", "corpus"] },
+      { id: "garden-to-upper-room", anchorIds: ["garden", "upper-room"] },
+    ],
+    decoder: {
+      id: "boot-house-v0.1",
+      version: "0.1",
+      interpolationStepsPerSegment: 4,
+      endpointPenaltyMultiplier: 1,
+    },
+  };
+}
+
+test("stdio adapter returns the native non-authoritative decoding", () => {
+  const child = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
+    { input: JSON.stringify(makeRequest()), encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 0, child.stderr);
+  const body = JSON.parse(child.stdout);
+  assert.equal(body.schema, "tranchnode.intent-stroke-process-result/v0.1");
+  assert.equal(body.status, "ok");
+  assert.equal(body.decoding.authority, "none");
+  assert.equal(body.decoding.candidates[0].templateId, "garden-to-corpus");
+});
+
+test("stdio adapter fails closed on an unsupported process schema", () => {
+  const child = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
+    {
+      input: JSON.stringify({ ...makeRequest(), schema: "tranchnode.intent-stroke-process/v9" }),
+      encoding: "utf8",
+    },
+  );
+
+  assert.notEqual(child.status, 0);
+  const body = JSON.parse(child.stdout);
+  assert.equal(body.status, "error");
+  assert.equal(body.code, "UNSUPPORTED_PROCESS_SCHEMA");
+});

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -76,3 +76,19 @@ test("stdio adapter fails closed on an unsupported process schema", () => {
   assert.equal(body.status, "error");
   assert.equal(body.code, "UNSUPPORTED_PROCESS_SCHEMA");
 });
+
+test("stdio adapter rejects input larger than one MiB", () => {
+  const child = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
+    {
+      input: JSON.stringify({ ...makeRequest(), padding: "x".repeat(1_048_576) }),
+      encoding: "utf8",
+    },
+  );
+
+  assert.notEqual(child.status, 0);
+  const body = JSON.parse(child.stdout);
+  assert.equal(body.status, "error");
+  assert.equal(body.code, "PROCESS_INPUT_TOO_LARGE");
+});


### PR DESCRIPTION
## Boot the House v0.1 — donor process port

Adds one repository-owned, one-shot JSON stdin/stdout adapter around the landed Intent Stroke decoder.

### Boundary

`npm run intent-stroke:stdio` delegates all addressing and decoding to TranchNode-native `addressIntentStroke`, `addressIntentStrokeFieldLayout`, and `decodeIntentStroke`. It does not introduce routing authority, selection authority, a second canonicalizer, or a network service.

Returned decoding remains `authority: "none"`.

### Process safety

- exact process schema: `tranchnode.intent-stroke-process/v0.1`
- only `decode` is supported
- stdin is hard-bounded to 1 MiB
- malformed/unsupported/oversized requests fail closed with structured error output

### TDD evidence

Initial boundary proof:
- RED head `d6914677125b86bbf2f7f573d0d6f7c250c8e207` — Actions `31993770191` failed with adapter absent
- GREEN head `3d983d3c2a952a9d7009c0ea90fa72244e1a11ea` — Actions `31993809486` passed

Riqor security follow-up:
- RED head `d7fd037d802f508cdbaed22a3a9d9c7a0f99bcba` — Actions `31994435437` failed on new oversized-input test
- GREEN head `7f3457fa9bd5f7e127800a1b0cc9e7f24af08d75` — Actions `31994567066` passed

### Status

Draft dependency PR for the federated Full Measure heartbeat. No merge requested yet.