### PR TITLE
feat: expose Intent Stroke v0.1 as a bounded stdio adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit && node --test --import tsx test/**/*.test.ts",
-    "test": "node --test --import tsx test/**/*.test.ts"
+    "test": "node --test --import tsx test/**/*.test.ts",
+    "intent-stroke:stdio": "node --import tsx scripts/intent-stroke-stdio.ts"
   },
   "dependencies": {
     "canonicalize": "^2.1.0"

--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -1,0 +1,92 @@
+import {
+  IntentStrokeError,
+  addressIntentStroke,
+  addressIntentStrokeFieldLayout,
+  decodeIntentStroke,
+  type IntentStroke,
+  type IntentStrokeDecoderIdentity,
+  type IntentStrokeFieldLayout,
+  type TraversalTemplate,
+} from "../src/intent-stroke.js";
+
+const REQUEST_SCHEMA = "tranchnode/intent-stroke-stdio/v0.1";
+const RESPONSE_SCHEMA = "tranchnode/intent-stroke-stdio-response/v0.1";
+
+type AdapterRequest = {
+  schema: typeof REQUEST_SCHEMA;
+  stroke: IntentStroke;
+  layout: IntentStrokeFieldLayout;
+  templates: TraversalTemplate[];
+  decoder: IntentStrokeDecoderIdentity;
+};
+
+type AdapterResponse =
+  | {
+      schema: typeof RESPONSE_SCHEMA;
+      ok: true;
+      decoding: ReturnType<typeof decodeIntentStroke>;
+    }
+  | {
+      schema: typeof RESPONSE_SCHEMA;
+      ok: false;
+      error: { code: string };
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(code: string): never {
+  const response: AdapterResponse = {
+    schema: RESPONSE_SCHEMA,
+    ok: false,
+    error: { code },
+  };
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+  process.exit(1);
+}
+
+async function readStdin(): Promise<string> {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) input += chunk;
+  return input;
+}
+
+async function main(): Promise<void> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readStdin());
+  } catch {
+    fail("MALFORMED_JSON");
+  }
+
+  if (!isRecord(parsed) || parsed.schema !== REQUEST_SCHEMA) {
+    fail("UNSUPPORTED_SCHEMA_VERSION");
+  }
+
+  const request = parsed as AdapterRequest;
+
+  try {
+    const layout = addressIntentStrokeFieldLayout(request.layout);
+    const stroke = addressIntentStroke(request.stroke);
+    const decoding = decodeIntentStroke({
+      stroke,
+      layout,
+      templates: request.templates,
+      decoder: request.decoder,
+    });
+
+    const response: AdapterResponse = {
+      schema: RESPONSE_SCHEMA,
+      ok: true,
+      decoding,
+    };
+    process.stdout.write(`${JSON.stringify(response)}\n`);
+  } catch (error: unknown) {
+    if (error instanceof IntentStrokeError) fail(error.code);
+    fail("INVALID_REQUEST");
+  }
+}
+
+await main();

--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -11,6 +11,7 @@ import {
 
 const REQUEST_SCHEMA = "tranchnode/intent-stroke-stdio/v0.1";
 const RESPONSE_SCHEMA = "tranchnode/intent-stroke-stdio-response/v0.1";
+const MAX_INPUT_BYTES = 1_048_576;
 
 type AdapterRequest = {
   schema: typeof REQUEST_SCHEMA;
@@ -48,8 +49,13 @@ function fail(code: string): never {
 
 async function readStdin(): Promise<string> {
   let input = "";
+  let inputBytes = 0;
   process.stdin.setEncoding("utf8");
-  for await (const chunk of process.stdin) input += chunk;
+  for await (const chunk of process.stdin) {
+    inputBytes += Buffer.byteLength(chunk, "utf8");
+    if (inputBytes > MAX_INPUT_BYTES) fail("INPUT_TOO_LARGE");
+    input += chunk;
+  }
   return input;
 }
 

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -106,6 +106,18 @@ test("stdio adapter rejects unsupported wrapper schema before decoding", async (
   });
 });
 
+test("stdio adapter rejects oversized raw requests before retaining an unbounded body", async () => {
+  const oversized = { ...request(), padding: "x".repeat(1_100_000) };
+  const result = await runAdapter(`${JSON.stringify(oversized)}\n`);
+  assert.equal(result.code, 1);
+  const response = JSON.parse(result.stdout) as any;
+  assert.deepEqual(response, {
+    schema: "tranchnode/intent-stroke-stdio-response/v0.1",
+    ok: false,
+    error: { code: "INPUT_TOO_LARGE" },
+  });
+});
+
 test("stdio adapter cannot manufacture crossing authority", async () => {
   const result = await runAdapter(`${JSON.stringify({ ...request(), authority: "grant" })}\n`);
   assert.equal(result.code, 0, result.stderr);

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  addressIntentStrokeFieldLayout,
+  type IntentStroke,
+  type IntentStrokeDecoderIdentity,
+  type IntentStrokeFieldLayout,
+  type IntentStrokePoint,
+  type TraversalTemplate,
+} from "../src/intent-stroke.js";
+
+interface Fixture {
+  layout: IntentStrokeFieldLayout;
+  decoder: IntentStrokeDecoderIdentity;
+  templates: TraversalTemplate[];
+  collisionTemplates: TraversalTemplate[];
+  strokes: {
+    intended: IntentStrokePoint[];
+  };
+}
+
+const fixture = JSON.parse(
+  await readFile(new URL("../fixtures/intent-stroke-v0.1.json", import.meta.url), "utf8"),
+) as Fixture;
+
+function makeStroke(points: IntentStrokePoint[]): IntentStroke {
+  return {
+    schema: "tranchnode/intent-stroke/v0.1",
+    fieldLayoutRef: addressIntentStrokeFieldLayout(fixture.layout).hash,
+    points,
+  };
+}
+
+async function runAdapter(input: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "scripts/intent-stroke-stdio.ts"],
+    { cwd: new URL("..", import.meta.url), stdio: ["pipe", "pipe", "pipe"] },
+  );
+  child.stdin.end(input);
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+
+  const code = await new Promise<number | null>((resolve) => child.on("close", resolve));
+  return { code, stdout, stderr };
+}
+
+function request(templates: TraversalTemplate[] = fixture.templates) {
+  return {
+    schema: "tranchnode/intent-stroke-stdio/v0.1",
+    stroke: makeStroke(fixture.strokes.intended),
+    layout: fixture.layout,
+    templates,
+    decoder: fixture.decoder,
+  };
+}
+
+test("stdio adapter returns the canonical non-authoritative decoding", async () => {
+  const result = await runAdapter(`${JSON.stringify(request())}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  assert.equal(response.schema, "tranchnode/intent-stroke-stdio-response/v0.1");
+  assert.equal(response.ok, true);
+  assert.equal(response.decoding.authority, "none");
+  assert.equal(response.decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+  assert.equal(response.decoding.ambiguity.kind, "none");
+  assert.match(response.decoding.fingerprint, /^sha256:[0-9a-f]{64}$/);
+});
+
+test("stdio adapter preserves exact decoder collisions", async () => {
+  const result = await runAdapter(`${JSON.stringify(request(fixture.collisionTemplates))}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  assert.equal(response.ok, true);
+  assert.equal(response.decoding.ambiguity.kind, "collision");
+  assert.deepEqual(response.decoding.ambiguity.leadingTemplateIds, ["portal-route-a", "portal-route-b"]);
+});
+
+test("stdio adapter reports malformed JSON as a structured adapter failure", async () => {
+  const result = await runAdapter("{not-json\n");
+  assert.equal(result.code, 1);
+  const response = JSON.parse(result.stdout) as any;
+  assert.deepEqual(response, {
+    schema: "tranchnode/intent-stroke-stdio-response/v0.1",
+    ok: false,
+    error: { code: "MALFORMED_JSON" },
+  });
+});
+
+test("stdio adapter rejects unsupported wrapper schema before decoding", async () => {
+  const bad = { ...request(), schema: "tranchnode/intent-stroke-stdio/v9" };
+  const result = await runAdapter(`${JSON.stringify(bad)}\n`);
+  assert.equal(result.code, 1);
+  const response = JSON.parse(result.stdout) as any;
+  assert.deepEqual(response, {
+    schema: "tranchnode/intent-stroke-stdio-response/v0.1",
+    ok: false,
+    error: { code: "UNSUPPORTED_SCHEMA_VERSION" },
+  });
+});
+
+test("stdio adapter cannot manufacture crossing authority", async () => {
+  const result = await runAdapter(`${JSON.stringify({ ...request(), authority: "grant" })}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  assert.equal(response.ok, true);
+  assert.equal(response.decoding.authority, "none");
+  assert.equal("authority" in response && response.authority !== undefined, false);
+});


### PR DESCRIPTION
## Summary

Implements #43 for Boot the House by exposing the already-landed Intent Stroke v0.1 decoder through a repo-owned bounded stdin/stdout adapter.

The adapter is intentionally thin: it addresses the supplied stroke/layout with TranchNode's existing helpers, calls the canonical decoder, and serializes the canonical decoding. It does **not** choose, confirm, or execute traversal and cannot mint crossing authority.

## Contract

- one versioned JSON request on stdin
- one versioned JSON response on stdout
- 1 MiB raw transport bound before unbounded retention
- canonical Intent Stroke decoder remains the sole ranking/ambiguity implementation
- `authority: "none"` is preserved
- exact equal-cost collisions remain unresolved
- malformed JSON, unsupported wrapper schema, and oversized transport input fail structurally
- caller-supplied top-level authority cannot escalate traversal

## TDD evidence

### RED 1 — missing adapter

Head `e4084d013d35c6cce416b94e5fe0304c6c1b66fc`, Actions run `32004357751`:
- existing suite passed
- all five new adapter tests failed because `scripts/intent-stroke-stdio.ts` did not exist
- result: 85 pass / 5 fail

### GREEN 1 — minimal wrapper

Head `4d6217edb3ea49bfffb86cabb1c68b5756564a6b`, Actions run `32004412210`:
- `npm run check` passed

### RED 2 — transport bound

Head `7dd6793ec219024fbc620057428d264223a4a650`, Actions run `32004487752`:
- 90/91 tests passed
- only the new oversized-input test failed because the adapter still accepted the body

### GREEN 2 — bounded transport

Head `f8f0de2a7f175153f2cc02962bb3309d7392576f`, Actions run `32004578528`:
- `npm run check` passed

## Security / authority review

Riqor-style owner review found and repaired the raw-input memory bound before readiness. The final adapter does not duplicate decoder semantics, inspect destination content, traverse, confirm, grant permission, or carry authority beyond the canonical `authority: "none"` decoding.

Closes #43