### PR TITLE
fix: let Intent Stroke stdio bind raw strokes to its layout

### DIFF
--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -13,9 +13,13 @@ const REQUEST_SCHEMA = "tranchnode/intent-stroke-stdio/v0.1";
 const RESPONSE_SCHEMA = "tranchnode/intent-stroke-stdio-response/v0.1";
 const MAX_INPUT_BYTES = 1_048_576;
 
+type AdapterStroke = Omit<IntentStroke, "fieldLayoutRef"> & {
+  fieldLayoutRef?: IntentStroke["fieldLayoutRef"];
+};
+
 type AdapterRequest = {
   schema: typeof REQUEST_SCHEMA;
-  stroke: IntentStroke;
+  stroke: AdapterStroke;
   layout: IntentStrokeFieldLayout;
   templates: TraversalTemplate[];
   decoder: IntentStrokeDecoderIdentity;
@@ -75,7 +79,10 @@ async function main(): Promise<void> {
 
   try {
     const layout = addressIntentStrokeFieldLayout(request.layout);
-    const stroke = addressIntentStroke(request.stroke);
+    const strokeValue: IntentStroke = request.stroke.fieldLayoutRef === undefined
+      ? { ...request.stroke, fieldLayoutRef: layout.hash }
+      : request.stroke as IntentStroke;
+    const stroke = addressIntentStroke(strokeValue);
     const decoding = decodeIntentStroke({
       stroke,
       layout,

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -91,7 +91,7 @@ test("stdio adapter can bind raw stroke points to the canonical supplied layout"
 
 test("stdio adapter preserves an explicit conflicting layout ref as a mismatch", async () => {
   const bad = request();
-  bad.stroke.fieldLayoutRef = "sha256:" + "0".repeat(64);
+  bad.stroke.fieldLayoutRef = `sha256:${"0".repeat(64)}` as IntentStroke["fieldLayoutRef"];
   const result = await runAdapter(`${JSON.stringify(bad)}\n`);
   assert.equal(result.code, 1);
   const response = JSON.parse(result.stdout) as any;

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -89,6 +89,19 @@ test("stdio adapter can bind raw stroke points to the canonical supplied layout"
   assert.equal(response.decoding.fieldLayoutRef, addressIntentStrokeFieldLayout(fixture.layout).hash);
 });
 
+test("stdio adapter preserves an explicit conflicting layout ref as a mismatch", async () => {
+  const bad = request();
+  bad.stroke.fieldLayoutRef = "sha256:" + "0".repeat(64);
+  const result = await runAdapter(`${JSON.stringify(bad)}\n`);
+  assert.equal(result.code, 1);
+  const response = JSON.parse(result.stdout) as any;
+  assert.deepEqual(response, {
+    schema: "tranchnode/intent-stroke-stdio-response/v0.1",
+    ok: false,
+    error: { code: "LAYOUT_REF_MISMATCH" },
+  });
+});
+
 test("stdio adapter preserves exact decoder collisions", async () => {
   const result = await runAdapter(`${JSON.stringify(request(fixture.collisionTemplates))}\n`);
   assert.equal(result.code, 0, result.stderr);

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -74,6 +74,21 @@ test("stdio adapter returns the canonical non-authoritative decoding", async () 
   assert.match(response.decoding.fingerprint, /^sha256:[0-9a-f]{64}$/);
 });
 
+test("stdio adapter can bind raw stroke points to the canonical supplied layout", async () => {
+  const existing = request();
+  const rawStroke = {
+    schema: existing.stroke.schema,
+    points: existing.stroke.points,
+  };
+  const result = await runAdapter(`${JSON.stringify({ ...existing, stroke: rawStroke })}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  assert.equal(response.ok, true);
+  assert.equal(response.decoding.authority, "none");
+  assert.equal(response.decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+  assert.equal(response.decoding.fieldLayoutRef, addressIntentStrokeFieldLayout(fixture.layout).hash);
+});
+
 test("stdio adapter preserves exact decoder collisions", async () => {
   const result = await runAdapter(`${JSON.stringify(request(fixture.collisionTemplates))}\n`);
   assert.equal(result.code, 0, result.stderr);


### PR DESCRIPTION
## Scope

Follow-up to landed PR #50 for Boot the House.

The landed stdio adapter accepted both `layout` and a stroke whose `fieldLayoutRef` normally had to equal TranchNode's canonical address of that layout. That forced an independent process consumer to precompute donor-owned identity before it could use the donor boundary.

This PR keeps existing pre-addressed v0.1 requests valid and adds one backward-compatible bootstrap: when `stroke.fieldLayoutRef` is omitted, TranchNode addresses the supplied layout itself and binds the raw stroke points to that canonical ref before using the existing `addressIntentStroke` + `decodeIntentStroke` path.

An explicitly supplied ref is never overwritten; a conflicting declaration still fails with `LAYOUT_REF_MISMATCH`.

## Invariants

- no second canonicalizer or hash implementation;
- existing `tranchnode/intent-stroke-stdio/v0.1` schema remains the process boundary;
- existing pre-addressed requests remain valid;
- `authority: "none"` remains unchanged;
- exact collision behavior remains unchanged;
- raw-input 1 MiB bound remains intact;
- no traversal selection, confirmation, or authority is added.

## TDD evidence

- RED head `d79249d2c9385152d16f9a30eff699bf65e8fe4a`, Actions run `32006634138`: **91/92** tests passed; only the new raw-layout-bootstrap test failed because `fieldLayoutRef` was required.
- GREEN implementation head `81cf8df52aa19204eee4ed0cd6d05eecf6d268f8`: full repository check passed after filling only an omitted ref through TranchNode's canonical layout address.
- Characterization commit `6f094dd559e4b7e0b0c9ed4de35d433dba9fe2b` initially exposed a test-fixture TypeScript type error before behavior executed; the fixture typing was corrected without changing the assertion.
- Exact final head `4566ec8960448e5dbca3f41058d9990f52e88052`, Actions run `32006926263`: full `npm run check` passed, including the explicit conflicting-ref `LAYOUT_REF_MISMATCH` regression proof.

## Compatibility effect

Backward-compatible widening of the existing local process request only. Donor identity remains TranchNode-owned.

Refs #51. Closes #51 when landed.