### PR TITLE
feat: bind raw Intent Stroke points to canonical layout in stdio v0.2

### DIFF
--- a/scripts/intent-stroke-stdio.ts
+++ b/scripts/intent-stroke-stdio.ts
@@ -6,29 +6,42 @@ import {
   type IntentStroke,
   type IntentStrokeDecoderIdentity,
   type IntentStrokeFieldLayout,
+  type IntentStrokePoint,
   type TraversalTemplate,
 } from "../src/intent-stroke.js";
 
-const REQUEST_SCHEMA = "tranchnode/intent-stroke-stdio/v0.1";
-const RESPONSE_SCHEMA = "tranchnode/intent-stroke-stdio-response/v0.1";
+const REQUEST_SCHEMA_V01 = "tranchnode/intent-stroke-stdio/v0.1";
+const REQUEST_SCHEMA_V02 = "tranchnode/intent-stroke-stdio/v0.2";
+const RESPONSE_SCHEMA_V01 = "tranchnode/intent-stroke-stdio-response/v0.1";
+const RESPONSE_SCHEMA_V02 = "tranchnode/intent-stroke-stdio-response/v0.2";
 const MAX_INPUT_BYTES = 1_048_576;
 
-type AdapterRequest = {
-  schema: typeof REQUEST_SCHEMA;
+type AdapterRequestV01 = {
+  schema: typeof REQUEST_SCHEMA_V01;
   stroke: IntentStroke;
   layout: IntentStrokeFieldLayout;
   templates: TraversalTemplate[];
   decoder: IntentStrokeDecoderIdentity;
 };
 
+type AdapterRequestV02 = {
+  schema: typeof REQUEST_SCHEMA_V02;
+  points: IntentStrokePoint[];
+  layout: IntentStrokeFieldLayout;
+  templates: TraversalTemplate[];
+  decoder: IntentStrokeDecoderIdentity;
+};
+
+type ResponseSchema = typeof RESPONSE_SCHEMA_V01 | typeof RESPONSE_SCHEMA_V02;
+
 type AdapterResponse =
   | {
-      schema: typeof RESPONSE_SCHEMA;
+      schema: ResponseSchema;
       ok: true;
       decoding: ReturnType<typeof decodeIntentStroke>;
     }
   | {
-      schema: typeof RESPONSE_SCHEMA;
+      schema: ResponseSchema;
       ok: false;
       error: { code: string };
     };
@@ -37,9 +50,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function fail(code: string): never {
+function responseSchemaFor(value: unknown): ResponseSchema {
+  return isRecord(value) && value.schema === REQUEST_SCHEMA_V02
+    ? RESPONSE_SCHEMA_V02
+    : RESPONSE_SCHEMA_V01;
+}
+
+function fail(code: string, schema: ResponseSchema = RESPONSE_SCHEMA_V01): never {
   const response: AdapterResponse = {
-    schema: RESPONSE_SCHEMA,
+    schema,
     ok: false,
     error: { code },
   };
@@ -67,15 +86,30 @@ async function main(): Promise<void> {
     fail("MALFORMED_JSON");
   }
 
-  if (!isRecord(parsed) || parsed.schema !== REQUEST_SCHEMA) {
+  if (
+    !isRecord(parsed) ||
+    (parsed.schema !== REQUEST_SCHEMA_V01 && parsed.schema !== REQUEST_SCHEMA_V02)
+  ) {
     fail("UNSUPPORTED_SCHEMA_VERSION");
   }
 
-  const request = parsed as AdapterRequest;
+  const responseSchema = responseSchemaFor(parsed);
 
   try {
-    const layout = addressIntentStrokeFieldLayout(request.layout);
-    const stroke = addressIntentStroke(request.stroke);
+    const layout = addressIntentStrokeFieldLayout(
+      (parsed as AdapterRequestV01 | AdapterRequestV02).layout,
+    );
+
+    const rawStroke: IntentStroke = parsed.schema === REQUEST_SCHEMA_V02
+      ? {
+          schema: "tranchnode/intent-stroke/v0.1",
+          fieldLayoutRef: layout.hash,
+          points: (parsed as AdapterRequestV02).points,
+        }
+      : (parsed as AdapterRequestV01).stroke;
+
+    const stroke = addressIntentStroke(rawStroke);
+    const request = parsed as AdapterRequestV01 | AdapterRequestV02;
     const decoding = decodeIntentStroke({
       stroke,
       layout,
@@ -84,14 +118,14 @@ async function main(): Promise<void> {
     });
 
     const response: AdapterResponse = {
-      schema: RESPONSE_SCHEMA,
+      schema: responseSchema,
       ok: true,
       decoding,
     };
     process.stdout.write(`${JSON.stringify(response)}\n`);
   } catch (error: unknown) {
-    if (error instanceof IntentStrokeError) fail(error.code);
-    fail("INVALID_REQUEST");
+    if (error instanceof IntentStrokeError) fail(error.code, responseSchema);
+    fail("INVALID_REQUEST", responseSchema);
   }
 }
 

--- a/test/intent-stroke-stdio.test.ts
+++ b/test/intent-stroke-stdio.test.ts
@@ -62,6 +62,16 @@ function request(templates: TraversalTemplate[] = fixture.templates) {
   };
 }
 
+function rawPointRequest(templates: TraversalTemplate[] = fixture.templates) {
+  return {
+    schema: "tranchnode/intent-stroke-stdio/v0.2",
+    points: fixture.strokes.intended,
+    layout: fixture.layout,
+    templates,
+    decoder: fixture.decoder,
+  };
+}
+
 test("stdio adapter returns the canonical non-authoritative decoding", async () => {
   const result = await runAdapter(`${JSON.stringify(request())}\n`);
   assert.equal(result.code, 0, result.stderr);
@@ -72,6 +82,29 @@ test("stdio adapter returns the canonical non-authoritative decoding", async () 
   assert.equal(response.decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
   assert.equal(response.decoding.ambiguity.kind, "none");
   assert.match(response.decoding.fingerprint, /^sha256:[0-9a-f]{64}$/);
+});
+
+test("v0.2 binds raw points to TranchNode's addressed layout before decoding", async () => {
+  const result = await runAdapter(`${JSON.stringify(rawPointRequest())}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  const expectedLayoutRef = addressIntentStrokeFieldLayout(fixture.layout).hash;
+
+  assert.equal(response.schema, "tranchnode/intent-stroke-stdio-response/v0.2");
+  assert.equal(response.ok, true);
+  assert.equal(response.decoding.fieldLayoutRef, expectedLayoutRef);
+  assert.equal(response.decoding.authority, "none");
+  assert.equal(response.decoding.candidates[0]?.templateId, "field-to-tranchnode-via-portal");
+  assert.equal("fieldLayoutRef" in rawPointRequest(), false);
+});
+
+test("v0.2 preserves collisions while binding the layout internally", async () => {
+  const result = await runAdapter(`${JSON.stringify(rawPointRequest(fixture.collisionTemplates))}\n`);
+  assert.equal(result.code, 0, result.stderr);
+  const response = JSON.parse(result.stdout) as any;
+  assert.equal(response.schema, "tranchnode/intent-stroke-stdio-response/v0.2");
+  assert.equal(response.decoding.ambiguity.kind, "collision");
+  assert.deepEqual(response.decoding.ambiguity.leadingTemplateIds, ["portal-route-a", "portal-route-b"]);
 });
 
 test("stdio adapter preserves exact decoder collisions", async () => {


### PR DESCRIPTION
## Boot the House integration follow-up

Implements #53 without changing Intent Stroke decoding semantics.

## Additive contract

The existing `intent-stroke:stdio` command now supports:
- v0.1 unchanged: caller supplies an already bound `stroke`;
- v0.2 additive: caller supplies raw `points` + declared `layout`, and TranchNode addresses the layout, constructs the canonical v0.1 stroke with that `fieldLayoutRef`, then delegates to the same canonical decoder.

## TDD evidence

RED head `e11c3fbc79bc3abd67b38f2bd3f6bd48aab98012`, Actions run `32008633333`:
- 91/93 tests passed;
- exactly the two new v0.2 tests failed because the wrapper rejected v0.2;
- all v0.1 behavior remained green.

GREEN exact head `d8722a217f8141dd5ecc61ff6c3c445daeb6afa7`, Actions run `32008684274`:
- full `npm run check` passed.

## Boundary

- no canonical addressing copied into callers;
- no decoder logic changed;
- `authority: "none"` remains canonical decoder output;
- collisions remain unresolved;
- transport bound and v0.1 compatibility remain intact;
- no traversal, destination access, or authority is added.

Closes #53