### PR TITLE
docs: refresh executable project status

### DIFF
--- a/PROJECT_STATUS.json
+++ b/PROJECT_STATUS.json
@@ -1,0 +1,22 @@
+{
+  "schema": "static-collective.project-status.v1",
+  "asOf": "2026-08-17",
+  "repository": "the-static-collective/tranchnode",
+  "defaultBranch": "main",
+  "project": "TranchNode",
+  "state": "active",
+  "phase": "Intent Stroke v0.2 process boundary",
+  "canonicalAuthority": "project-owned repository",
+  "observedMainCommit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197",
+  "executableSurface": [
+    {"id": "residual-v0.1", "status": "landed", "interface": "TypeScript library/tests"},
+    {"id": "intent-stroke-decoder-v0.1", "status": "landed", "evidence": {"commit": "efc75f6228a2d9c16475378d0dc382a48bf762c8", "pullRequest": 41}},
+    {"id": "intent-stroke-stdio-v0.1", "status": "landed", "evidence": {"commit": "a3dc7fa5155df93641f4f116eac1464b10342849", "pullRequest": 50}},
+    {"id": "intent-stroke-stdio-v0.2-raw-points", "status": "landed", "interface": "npm run intent-stroke:stdio", "evidence": {"commit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197", "pullRequest": 54}}
+  ],
+  "nonClaims": [
+    "retrieval is not authority",
+    "decoded intent does not authorize traversal",
+    "raw pointer transport does not transfer caller authority"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,9 +21,31 @@ See [`INVARIANTS.md`](./INVARIANTS.md) for the authoritative invariant set.
 
 ## Current executable surface
 
-The repository currently includes a TypeScript implementation of residual extraction and validation in [`src/residual.ts`](./src/residual.ts), with characterization and residual tests under [`test/`](./test/).
+The executable surface is now broader than residual extraction alone.
 
-The executable surface is intentionally narrower than the full architecture. The documents define the governing contracts; code is added in bounded slices that make those contracts mechanically testable.
+It includes:
+
+- TypeScript residual extraction and validation;
+- **Intent Stroke v0.1** traversal decoding with deterministic candidate/ambiguity evidence;
+- a bounded stdio process adapter for Intent Stroke;
+- **Intent Stroke stdio v0.2**, which accepts raw pointer points and binds them to the donor-owned canonical field layout before decoding.
+
+The process seam deliberately carries observation, not crossing authority. A decoded gesture may expose a candidate route; it does not authorize the destination or silently choose a crossing.
+
+Run the complete repository proof:
+
+```bash
+npm install
+npm run check
+```
+
+Run the bounded Intent Stroke process seam:
+
+```bash
+npm run intent-stroke:stdio
+```
+
+Machine-readable snapshot: [`PROJECT_STATUS.json`](PROJECT_STATUS.json).
 
 ## Architecture map
 
@@ -38,22 +60,8 @@ Start here:
 - [`PROJECTION_COVENANT.md`](./PROJECTION_COVENANT.md) — projection rules and limits.
 - [`COMPATIBILITY.md`](./COMPATIBILITY.md) — implementation compatibility floor.
 - [`PROJECT_LEGO_FLOOR_1_0.md`](./PROJECT_LEGO_FLOOR_1_0.md) — composable project floor.
-- [`RESIDUAL_V0_1.md`](./RESIDUAL_V0_1.md) — current residual contract.
-
-Additional focused documents and fixtures live under [`docs/`](./docs/) and [`fixtures/`](./fixtures/).
-
-## Development
-
-Requires a current Node.js runtime with npm.
-
-```bash
-npm install
-npm test
-npm run check
-```
-
-- `npm test` runs the Node test suite through `tsx`.
-- `npm run check` runs TypeScript validation and the full test suite.
+- [`RESIDUAL_V0_1.md`](./RESIDUAL_V0_1.md) — residual contract.
+- [`docs/`](./docs/) and [`fixtures/`](./fixtures/) — focused executable designs, plans, and proof material.
 
 ## Design posture
 
@@ -63,4 +71,6 @@ Applications are replaceable interfaces. Retrieval proposes relevant material. M
 
 ## Status
 
-TranchNode is under active development. The repository contains both adopted architectural law and bounded executable proofs. Historical proposals should be read through their inheritance and supersession links rather than assumed to be live integration choices.
+TranchNode is under active development. The repository contains both adopted architectural law and bounded executable proofs. Its newest process-facing proof turns raw human traversal input into deterministic, inspectable candidate evidence while leaving destination authority outside the decoder.
+
+Historical proposals should be read through their inheritance and supersession links rather than assumed to be live integration choices.


### PR DESCRIPTION
## What changed

- updates the README beyond residual-only execution;
- records Intent Stroke v0.1/v0.2 and the bounded stdio process seam;
- adds `PROJECT_STATUS.json` using `static-collective.project-status.v1`.

## Why

TranchNode now has a real traversal-decoding process boundary that the prior README did not expose.

## Verification

- fetched both changed files back from the remote branch;
- parsed the remote-fetched `PROJECT_STATUS.json` payload successfully;
- no runtime files changed, so this PR makes no fresh runtime-test claim.