### PR TITLE
feat: prove Continuity Spine v0.1

### DIFF
--- a/fixtures/continuity-spine/intent-stroke-v01-to-v02.json
+++ b/fixtures/continuity-spine/intent-stroke-v01-to-v02.json
@@ -1,0 +1,142 @@
+{
+  "schema": "tranchnode/continuity-spine/v0.1",
+  "id": "intent-stroke-v01-to-v02",
+  "project": "TranchNode",
+  "origin": {
+    "id": "intent-stroke-stdio-v0.1",
+    "status": "historical",
+    "sourceRef": "pull-request:50",
+    "observedCommit": "a3dc7fa5155df93641f4f116eac1464b10342849"
+  },
+  "present": {
+    "id": "intent-stroke-stdio-v0.2-overlap",
+    "status": "constituted",
+    "sourceRef": "pull-request:54",
+    "observedCommit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197"
+  },
+  "attractor": {
+    "id": "raw-point-callers-need-no-canonical-layout-ref",
+    "status": "proposal",
+    "purpose": "Let v0.2 callers supply raw points plus declared layout while TranchNode owns canonical layout binding.",
+    "desiredCapabilities": [
+      "caller-may-omit-fieldLayoutRef"
+    ],
+    "nonClaims": [
+      "future state is not constituted by declaration",
+      "raw pointer transport grants no traversal authority"
+    ]
+  },
+  "stageOrder": [
+    "v0.1-caller-bound",
+    "v0.1-v0.2-overlap"
+  ],
+  "invariants": [
+    {
+      "id": "v0.1-compatibility",
+      "description": "The v0.1 stdio request remains supported during the overlap.",
+      "sourceRef": "pull-request:54",
+      "appliesThrough": "all",
+      "requiredCarries": [
+        "interface:intent-stroke-stdio-v0.1"
+      ]
+    },
+    {
+      "id": "decoder-authority-none",
+      "description": "Intent Stroke decoding remains non-authoritative.",
+      "sourceRef": "pull-request:54",
+      "appliesThrough": "all",
+      "requiredCarries": [
+        "decoder-authority:none"
+      ]
+    },
+    {
+      "id": "collision-remains-unresolved",
+      "description": "Equal-cost decoder collisions are preserved rather than silently selected.",
+      "sourceRef": "pull-request:54",
+      "appliesThrough": "all",
+      "requiredCarries": [
+        "collision-policy:unresolved"
+      ]
+    },
+    {
+      "id": "raw-transport-no-traversal-authority",
+      "description": "Raw point transport does not grant traversal or caller authority.",
+      "sourceRef": "pull-request:54",
+      "appliesThrough": "all",
+      "requiredCarries": [
+        "transport-authority:none"
+      ]
+    },
+    {
+      "id": "canonical-addressing-inside-tranchnode",
+      "description": "Canonical layout addressing for v0.2 is performed inside TranchNode.",
+      "sourceRef": "pull-request:54",
+      "appliesThrough": [
+        "v0.1-v0.2-overlap"
+      ],
+      "requiredCarries": [
+        "layout-binding:tranchnode"
+      ]
+    }
+  ],
+  "stages": [
+    {
+      "id": "v0.1-caller-bound",
+      "status": "historical",
+      "carries": [
+        "interface:intent-stroke-stdio-v0.1",
+        "decoder-authority:none",
+        "collision-policy:unresolved",
+        "transport-authority:none",
+        "responsibility:canonical-layout-binding"
+      ],
+      "dependsOn": [
+        "dependency:caller-constructs-fieldLayoutRef"
+      ],
+      "scaffolds": [
+        "dependency:caller-constructs-fieldLayoutRef"
+      ],
+      "entryConditions": [],
+      "exitConditions": [
+        "transfer:canonical-layout-binding-to-tranchnode"
+      ]
+    },
+    {
+      "id": "v0.1-v0.2-overlap",
+      "status": "constituted",
+      "carries": [
+        "interface:intent-stroke-stdio-v0.1",
+        "interface:intent-stroke-stdio-v0.2",
+        "decoder-authority:none",
+        "collision-policy:unresolved",
+        "transport-authority:none",
+        "responsibility:canonical-layout-binding",
+        "layout-binding:tranchnode"
+      ],
+      "dependsOn": [],
+      "scaffolds": [],
+      "entryConditions": [
+        "witness:pr54-green",
+        "witness:pr54-boundary-review"
+      ],
+      "exitConditions": []
+    }
+  ],
+  "transfers": [
+    {
+      "id": "transfer:canonical-layout-binding-to-tranchnode",
+      "responsibilityId": "responsibility:canonical-layout-binding",
+      "fromCarrier": "v0.2-caller-boundary",
+      "toCarrier": "tranchnode",
+      "sourceStageId": "v0.1-caller-bound",
+      "destinationStageId": "v0.1-v0.2-overlap",
+      "requiredWitnessIds": [
+        "witness:pr54-green",
+        "witness:pr54-boundary-review"
+      ],
+      "permitsShedding": [
+        "dependency:caller-constructs-fieldLayoutRef"
+      ]
+    }
+  ]
+}

--- a/src/continuity-spine.ts
+++ b/src/continuity-spine.ts
@@ -1,0 +1,316 @@
+const MANIFEST_SCHEMA = "tranchnode/continuity-spine/v0.1" as const;
+const EVALUATION_SCHEMA = "tranchnode/continuity-spine-evaluation/v0.1" as const;
+
+export type StageStatus = "historical" | "constituted" | "proposal";
+
+export interface ContinuityStateRef {
+  id: string;
+  status: "historical" | "constituted";
+  sourceRef: string;
+  observedCommit?: string;
+}
+
+export interface ContinuityAttractorRef {
+  id: string;
+  status: "proposal";
+  purpose: string;
+  desiredCapabilities: string[];
+  nonClaims: string[];
+}
+
+export interface ContinuityInvariant {
+  id: string;
+  description: string;
+  sourceRef: string;
+  appliesThrough: "all" | string[];
+  requiredCarries: string[];
+}
+
+export interface ContinuityStage {
+  id: string;
+  status: StageStatus;
+  carries: string[];
+  dependsOn: string[];
+  scaffolds: string[];
+  entryConditions: string[];
+  exitConditions: string[];
+}
+
+export interface ContinuityTransfer {
+  id: string;
+  responsibilityId: string;
+  fromCarrier: string;
+  toCarrier: string;
+  sourceStageId: string;
+  destinationStageId: string;
+  requiredWitnessIds: string[];
+  permitsShedding: string[];
+}
+
+export interface ContinuitySpineManifestV01 {
+  schema: typeof MANIFEST_SCHEMA;
+  id: string;
+  project: string;
+  origin: ContinuityStateRef;
+  present: ContinuityStateRef;
+  attractor: ContinuityAttractorRef;
+  stageOrder: string[];
+  invariants: ContinuityInvariant[];
+  stages: ContinuityStage[];
+  transfers: ContinuityTransfer[];
+}
+
+export type TransitionDecision = "admissible" | "blocked" | "invalid";
+
+export type TransitionFindingClass =
+  | "proposal_only"
+  | "blocked_invariant_loss"
+  | "blocked_untransferred_responsibility"
+  | "blocked_unwitnessed_transfer"
+  | "blocked_premature_shedding"
+  | "invalid_manifest";
+
+export interface TransitionFinding {
+  class: TransitionFindingClass;
+  subjectId: string;
+  reason: string;
+}
+
+export interface TransitionEvaluationInput {
+  spine: ContinuitySpineManifestV01;
+  fromStageId: string;
+  toStageId: string;
+  suppliedWitnesses: string[];
+}
+
+export interface TransitionEvaluation {
+  schema: typeof EVALUATION_SCHEMA;
+  spineId: string;
+  fromStageId: string;
+  toStageId: string;
+  decision: TransitionDecision;
+  shed: string[];
+  completedTransferIds: string[];
+  findings: TransitionFinding[];
+}
+
+export class ContinuitySpineError extends Error {
+  constructor(public readonly code: string) {
+    super(code);
+    this.name = "ContinuitySpineError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new ContinuitySpineError("INVALID_MANIFEST");
+  return value;
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ContinuitySpineError("INVALID_MANIFEST");
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredString(value);
+}
+
+function uniqueStrings(value: unknown, allowEmpty = true): string[] {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new ContinuitySpineError("INVALID_MANIFEST");
+  }
+  const result = value.map(requiredString);
+  if (new Set(result).size !== result.length) {
+    throw new ContinuitySpineError("DUPLICATE_ID");
+  }
+  return result;
+}
+
+function assertUniqueIds(items: Array<{ id: string }>): void {
+  const ids = items.map((item) => item.id);
+  if (new Set(ids).size !== ids.length) {
+    throw new ContinuitySpineError("DUPLICATE_ID");
+  }
+}
+
+function parseStateRef(value: unknown): ContinuityStateRef {
+  const record = requiredRecord(value);
+  const status = requiredString(record.status);
+  if (status !== "historical" && status !== "constituted") {
+    throw new ContinuitySpineError("INVALID_MANIFEST");
+  }
+  const observedCommit = optionalString(record.observedCommit);
+  return {
+    id: requiredString(record.id),
+    status,
+    sourceRef: requiredString(record.sourceRef),
+    ...(observedCommit === undefined ? {} : { observedCommit }),
+  };
+}
+
+function parseAttractor(value: unknown): ContinuityAttractorRef {
+  const record = requiredRecord(value);
+  const status = requiredString(record.status);
+  if (status !== "proposal") {
+    throw new ContinuitySpineError("ATTRACTOR_MUST_BE_PROPOSAL");
+  }
+  return {
+    id: requiredString(record.id),
+    status,
+    purpose: requiredString(record.purpose),
+    desiredCapabilities: uniqueStrings(record.desiredCapabilities, false),
+    nonClaims: uniqueStrings(record.nonClaims, false),
+  };
+}
+
+function parseInvariant(value: unknown): ContinuityInvariant {
+  const record = requiredRecord(value);
+  const rawAppliesThrough = record.appliesThrough;
+  const appliesThrough = rawAppliesThrough === "all"
+    ? "all"
+    : uniqueStrings(rawAppliesThrough, false);
+  return {
+    id: requiredString(record.id),
+    description: requiredString(record.description),
+    sourceRef: requiredString(record.sourceRef),
+    appliesThrough,
+    requiredCarries: uniqueStrings(record.requiredCarries, false),
+  };
+}
+
+function parseStage(value: unknown): ContinuityStage {
+  const record = requiredRecord(value);
+  const status = requiredString(record.status);
+  if (status !== "historical" && status !== "constituted" && status !== "proposal") {
+    throw new ContinuitySpineError("INVALID_MANIFEST");
+  }
+  return {
+    id: requiredString(record.id),
+    status,
+    carries: uniqueStrings(record.carries),
+    dependsOn: uniqueStrings(record.dependsOn),
+    scaffolds: uniqueStrings(record.scaffolds),
+    entryConditions: uniqueStrings(record.entryConditions),
+    exitConditions: uniqueStrings(record.exitConditions),
+  };
+}
+
+function parseTransfer(value: unknown): ContinuityTransfer {
+  const record = requiredRecord(value);
+  return {
+    id: requiredString(record.id),
+    responsibilityId: requiredString(record.responsibilityId),
+    fromCarrier: requiredString(record.fromCarrier),
+    toCarrier: requiredString(record.toCarrier),
+    sourceStageId: requiredString(record.sourceStageId),
+    destinationStageId: requiredString(record.destinationStageId),
+    requiredWitnessIds: uniqueStrings(record.requiredWitnessIds, false),
+    permitsShedding: uniqueStrings(record.permitsShedding),
+  };
+}
+
+function parseArray<T>(value: unknown, parser: (item: unknown) => T): T[] {
+  if (!Array.isArray(value)) throw new ContinuitySpineError("INVALID_MANIFEST");
+  return value.map(parser);
+}
+
+export function validateContinuitySpineManifest(value: unknown): ContinuitySpineManifestV01 {
+  const record = requiredRecord(value);
+  if (record.schema !== MANIFEST_SCHEMA) {
+    throw new ContinuitySpineError("UNSUPPORTED_SCHEMA_VERSION");
+  }
+
+  const origin = parseStateRef(record.origin);
+  const present = parseStateRef(record.present);
+  const attractor = parseAttractor(record.attractor);
+  const invariants = parseArray(record.invariants, parseInvariant);
+  const stages = parseArray(record.stages, parseStage);
+  const transfers = parseArray(record.transfers, parseTransfer);
+  const stageOrder = uniqueStrings(record.stageOrder, false);
+
+  assertUniqueIds(invariants);
+  assertUniqueIds(stages);
+  assertUniqueIds(transfers);
+
+  const stageIds = new Set(stages.map((stage) => stage.id));
+  if (
+    stageOrder.length !== stages.length
+    || stageOrder.some((id) => !stageIds.has(id))
+    || stages.some((stage) => !stageOrder.includes(stage.id))
+  ) {
+    throw new ContinuitySpineError("INVALID_STAGE_ORDER");
+  }
+
+  const orderIndex = new Map(stageOrder.map((id, index) => [id, index]));
+
+  for (const invariant of invariants) {
+    if (
+      invariant.appliesThrough !== "all"
+      && invariant.appliesThrough.some((stageId) => !stageIds.has(stageId))
+    ) {
+      throw new ContinuitySpineError("BROKEN_STAGE_REFERENCE");
+    }
+  }
+
+  for (const transfer of transfers) {
+    const sourceIndex = orderIndex.get(transfer.sourceStageId);
+    const destinationIndex = orderIndex.get(transfer.destinationStageId);
+    if (sourceIndex === undefined || destinationIndex === undefined) {
+      throw new ContinuitySpineError("BROKEN_STAGE_REFERENCE");
+    }
+    if (sourceIndex >= destinationIndex) {
+      throw new ContinuitySpineError("INVALID_STAGE_ORDER");
+    }
+    const sourceStage = stages.find((stage) => stage.id === transfer.sourceStageId);
+    const destinationStage = stages.find((stage) => stage.id === transfer.destinationStageId);
+    if (
+      sourceStage === undefined
+      || destinationStage === undefined
+      || !sourceStage.carries.includes(transfer.responsibilityId)
+      || !destinationStage.carries.includes(transfer.responsibilityId)
+    ) {
+      throw new ContinuitySpineError("BROKEN_STAGE_REFERENCE");
+    }
+  }
+
+  return {
+    schema: MANIFEST_SCHEMA,
+    id: requiredString(record.id),
+    project: requiredString(record.project),
+    origin,
+    present,
+    attractor,
+    stageOrder: [...stageOrder],
+    invariants: invariants.map((invariant) => ({
+      ...invariant,
+      appliesThrough: invariant.appliesThrough === "all"
+        ? "all"
+        : [...invariant.appliesThrough],
+      requiredCarries: [...invariant.requiredCarries],
+    })),
+    stages: stages.map((stage) => ({
+      ...stage,
+      carries: [...stage.carries],
+      dependsOn: [...stage.dependsOn],
+      scaffolds: [...stage.scaffolds],
+      entryConditions: [...stage.entryConditions],
+      exitConditions: [...stage.exitConditions],
+    })),
+    transfers: transfers.map((transfer) => ({
+      ...transfer,
+      requiredWitnessIds: [...transfer.requiredWitnessIds],
+      permitsShedding: [...transfer.permitsShedding],
+    })),
+  };
+}
+
+export function evaluateStageTransition(_input: TransitionEvaluationInput): TransitionEvaluation {
+  throw new ContinuitySpineError("NOT_IMPLEMENTED");
+}

--- a/src/continuity-spine.ts
+++ b/src/continuity-spine.ts
@@ -133,6 +133,17 @@ function uniqueStrings(value: unknown, allowEmpty = true): string[] {
   return result;
 }
 
+function stageOrderStrings(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ContinuitySpineError("INVALID_STAGE_ORDER");
+  }
+  const result = value.map(requiredString);
+  if (new Set(result).size !== result.length) {
+    throw new ContinuitySpineError("INVALID_STAGE_ORDER");
+  }
+  return result;
+}
+
 function assertUniqueIds(items: Array<{ id: string }>): void {
   const ids = items.map((item) => item.id);
   if (new Set(ids).size !== ids.length) {
@@ -233,7 +244,7 @@ export function validateContinuitySpineManifest(value: unknown): ContinuitySpine
   const invariants = parseArray(record.invariants, parseInvariant);
   const stages = parseArray(record.stages, parseStage);
   const transfers = parseArray(record.transfers, parseTransfer);
-  const stageOrder = uniqueStrings(record.stageOrder, false);
+  const stageOrder = stageOrderStrings(record.stageOrder);
 
   assertUniqueIds(invariants);
   assertUniqueIds(stages);

--- a/src/continuity-spine.ts
+++ b/src/continuity-spine.ts
@@ -322,6 +322,234 @@ export function validateContinuitySpineManifest(value: unknown): ContinuitySpine
   };
 }
 
-export function evaluateStageTransition(_input: TransitionEvaluationInput): TransitionEvaluation {
-  throw new ContinuitySpineError("NOT_IMPLEMENTED");
+function sortFindings(findings: TransitionFinding[]): TransitionFinding[] {
+  return [...findings].sort((left, right) =>
+    left.class.localeCompare(right.class)
+    || left.subjectId.localeCompare(right.subjectId)
+    || left.reason.localeCompare(right.reason)
+  );
+}
+
+function invalidEvaluation(
+  spineId: string,
+  fromStageId: string,
+  toStageId: string,
+  subjectId: string,
+  reason: string,
+): TransitionEvaluation {
+  return {
+    schema: EVALUATION_SCHEMA,
+    spineId,
+    fromStageId,
+    toStageId,
+    decision: "invalid",
+    shed: [],
+    completedTransferIds: [],
+    findings: [{ class: "invalid_manifest", subjectId, reason }],
+  };
+}
+
+function bestEffortSpineId(value: unknown): string {
+  if (isRecord(value) && typeof value.id === "string" && value.id.length > 0) {
+    return value.id;
+  }
+  return "unknown-spine";
+}
+
+export function evaluateStageTransition(input: TransitionEvaluationInput): TransitionEvaluation {
+  const rawSpine: unknown = input.spine;
+  let spine: ContinuitySpineManifestV01;
+  try {
+    spine = validateContinuitySpineManifest(rawSpine);
+  } catch (error: unknown) {
+    const reason = error instanceof ContinuitySpineError ? error.code : "INVALID_MANIFEST";
+    return invalidEvaluation(
+      bestEffortSpineId(rawSpine),
+      input.fromStageId,
+      input.toStageId,
+      bestEffortSpineId(rawSpine),
+      reason,
+    );
+  }
+
+  if (!Array.isArray(input.suppliedWitnesses)) {
+    return invalidEvaluation(
+      spine.id,
+      input.fromStageId,
+      input.toStageId,
+      spine.id,
+      "INVALID_SUPPLIED_WITNESSES",
+    );
+  }
+
+  const suppliedWitnesses: string[] = [];
+  for (const witness of input.suppliedWitnesses) {
+    if (typeof witness !== "string" || witness.trim().length === 0) {
+      return invalidEvaluation(
+        spine.id,
+        input.fromStageId,
+        input.toStageId,
+        spine.id,
+        "INVALID_SUPPLIED_WITNESSES",
+      );
+    }
+    if (!suppliedWitnesses.includes(witness)) suppliedWitnesses.push(witness);
+  }
+  suppliedWitnesses.sort();
+
+  const knownWitnesses = new Set(
+    spine.transfers.flatMap((transfer) => transfer.requiredWitnessIds),
+  );
+  const unknownWitness = suppliedWitnesses.find((witness) => !knownWitnesses.has(witness));
+  if (unknownWitness !== undefined) {
+    return invalidEvaluation(
+      spine.id,
+      input.fromStageId,
+      input.toStageId,
+      unknownWitness,
+      "UNKNOWN_SUPPLIED_WITNESS",
+    );
+  }
+
+  const fromIndex = spine.stageOrder.indexOf(input.fromStageId);
+  const toIndex = spine.stageOrder.indexOf(input.toStageId);
+  if (fromIndex < 0 || toIndex < 0) {
+    const unknownStage = fromIndex < 0 ? input.fromStageId : input.toStageId;
+    return invalidEvaluation(
+      spine.id,
+      input.fromStageId,
+      input.toStageId,
+      unknownStage,
+      "UNKNOWN_STAGE",
+    );
+  }
+  if (fromIndex >= toIndex) {
+    return invalidEvaluation(
+      spine.id,
+      input.fromStageId,
+      input.toStageId,
+      `${input.fromStageId}->${input.toStageId}`,
+      "INVALID_TRANSITION_ORDER",
+    );
+  }
+
+  const from = spine.stages.find((stage) => stage.id === input.fromStageId);
+  const to = spine.stages.find((stage) => stage.id === input.toStageId);
+  if (from === undefined || to === undefined) {
+    return invalidEvaluation(
+      spine.id,
+      input.fromStageId,
+      input.toStageId,
+      `${input.fromStageId}->${input.toStageId}`,
+      "UNKNOWN_STAGE",
+    );
+  }
+
+  const sourceMaterial = new Set([
+    ...from.carries,
+    ...from.dependsOn,
+    ...from.scaffolds,
+  ]);
+  const destinationMaterial = new Set([
+    ...to.carries,
+    ...to.dependsOn,
+    ...to.scaffolds,
+  ]);
+  const shed = [...sourceMaterial]
+    .filter((id) => !destinationMaterial.has(id))
+    .sort();
+
+  const findings: TransitionFinding[] = [];
+  if (to.status === "proposal") {
+    findings.push({
+      class: "proposal_only",
+      subjectId: to.id,
+      reason: "DESTINATION_REMAINS_PROPOSAL",
+    });
+  }
+
+  for (const invariant of spine.invariants) {
+    const applies = invariant.appliesThrough === "all"
+      || invariant.appliesThrough.includes(to.id);
+    if (!applies) continue;
+
+    for (const requiredCarry of invariant.requiredCarries) {
+      if (!to.carries.includes(requiredCarry)) {
+        findings.push({
+          class: "blocked_invariant_loss",
+          subjectId: invariant.id,
+          reason: "ACTIVE_INVARIANT_CARRIER_MISSING",
+        });
+      }
+    }
+  }
+
+  const suppliedWitnessSet = new Set(suppliedWitnesses);
+  const relevantTransfers = spine.transfers.filter(
+    (transfer) => transfer.sourceStageId === from.id
+      && transfer.destinationStageId === to.id,
+  );
+  const completedTransfers = relevantTransfers.filter((transfer) =>
+    transfer.requiredWitnessIds.every((witness) => suppliedWitnessSet.has(witness))
+  );
+  const completedTransferIds = completedTransfers.map((transfer) => transfer.id).sort();
+  const completedTransferIdSet = new Set(completedTransferIds);
+
+  for (const transfer of relevantTransfers) {
+    if (!completedTransferIdSet.has(transfer.id)) {
+      findings.push({
+        class: "blocked_unwitnessed_transfer",
+        subjectId: transfer.id,
+        reason: "REQUIRED_TRANSFER_WITNESS_MISSING",
+      });
+    }
+  }
+
+  for (const shedId of shed) {
+    const permittingTransfers = relevantTransfers.filter(
+      (transfer) => transfer.permitsShedding.includes(shedId),
+    );
+    const hasCompletedPermission = permittingTransfers.some(
+      (transfer) => completedTransferIdSet.has(transfer.id),
+    );
+
+    if (hasCompletedPermission) continue;
+
+    if (permittingTransfers.length > 0) {
+      findings.push({
+        class: "blocked_premature_shedding",
+        subjectId: shedId,
+        reason: "SHED_BEFORE_TRANSFER_WITNESS",
+      });
+      continue;
+    }
+
+    if (from.carries.includes(shedId)) {
+      findings.push({
+        class: "blocked_untransferred_responsibility",
+        subjectId: shedId,
+        reason: "RESPONSIBILITY_DROPPED_WITHOUT_TRANSFER",
+      });
+    } else {
+      findings.push({
+        class: "blocked_premature_shedding",
+        subjectId: shedId,
+        reason: "SHED_WITHOUT_TRANSFER_PERMISSION",
+      });
+    }
+  }
+
+  const normalizedFindings = sortFindings(findings);
+  const blocked = normalizedFindings.some((finding) => finding.class.startsWith("blocked_"));
+
+  return {
+    schema: EVALUATION_SCHEMA,
+    spineId: spine.id,
+    fromStageId: from.id,
+    toStageId: to.id,
+    decision: blocked ? "blocked" : "admissible",
+    shed,
+    completedTransferIds,
+    findings: normalizedFindings,
+  };
 }

--- a/test/continuity-spine.test.ts
+++ b/test/continuity-spine.test.ts
@@ -312,3 +312,69 @@ test("Intent Stroke refuses to drop responsibility when no transfer carries it f
     ),
   );
 });
+
+test("transition evaluation does not mutate manifest or supplied witnesses", async () => {
+  const spine = await rawFixture();
+  const witnesses = ["witness:pr54-green", "witness:pr54-boundary-review"];
+  const spineBefore = structuredClone(spine);
+  const witnessesBefore = [...witnesses];
+
+  evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: witnesses,
+  });
+
+  assert.deepEqual(spine, spineBefore);
+  assert.deepEqual(witnesses, witnessesBefore);
+});
+
+test("repeated transition evaluation is structurally stable", async () => {
+  const spine = validateContinuitySpineManifest(await rawFixture());
+  const input = {
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:pr54-boundary-review"],
+  };
+
+  assert.deepEqual(evaluateStageTransition(input), evaluateStageTransition(input));
+});
+
+test("supplied witness order cannot alter transition evaluation", async () => {
+  const spine = validateContinuitySpineManifest(await rawFixture());
+  const forward = evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:pr54-boundary-review"],
+  });
+  const reversed = evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-boundary-review", "witness:pr54-green"],
+  });
+
+  assert.deepEqual(forward, reversed);
+});
+
+test("unknown supplied witness fails closed", async () => {
+  const spine = validateContinuitySpineManifest(await rawFixture());
+  const result = evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:not-declared"],
+  });
+
+  assert.equal(result.decision, "invalid");
+  assert.ok(
+    result.findings.some(
+      (finding) => finding.class === "invalid_manifest"
+        && finding.subjectId === "witness:not-declared"
+        && finding.reason === "UNKNOWN_SUPPLIED_WITNESS",
+    ),
+  );
+});

--- a/test/continuity-spine.test.ts
+++ b/test/continuity-spine.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ContinuitySpineError,
+  validateContinuitySpineManifest,
+  type ContinuitySpineManifestV01,
+} from "../src/continuity-spine.js";
+
+function minimalManifest(): ContinuitySpineManifestV01 {
+  return {
+    schema: "tranchnode/continuity-spine/v0.1",
+    id: "minimal-spine",
+    project: "TranchNode",
+    origin: {
+      id: "origin",
+      status: "historical",
+      sourceRef: "commit:origin",
+    },
+    present: {
+      id: "present",
+      status: "constituted",
+      sourceRef: "commit:present",
+    },
+    attractor: {
+      id: "attractor",
+      status: "proposal",
+      purpose: "Prove staged continuity.",
+      desiredCapabilities: ["capability:b"],
+      nonClaims: ["future state is not constituted by declaration"],
+    },
+    stageOrder: ["stage-a", "stage-b"],
+    invariants: [
+      {
+        id: "decoder-authority-none",
+        description: "Decoder remains non-authoritative.",
+        sourceRef: "test:fixture",
+        appliesThrough: "all",
+        requiredCarries: ["decoder-authority:none"],
+      },
+    ],
+    stages: [
+      {
+        id: "stage-a",
+        status: "historical",
+        carries: ["decoder-authority:none", "responsibility:layout-binding"],
+        dependsOn: ["dependency:caller-layout-ref"],
+        scaffolds: ["dependency:caller-layout-ref"],
+        entryConditions: [],
+        exitConditions: ["transfer:layout-binding"],
+      },
+      {
+        id: "stage-b",
+        status: "constituted",
+        carries: ["decoder-authority:none", "responsibility:layout-binding"],
+        dependsOn: [],
+        scaffolds: [],
+        entryConditions: ["witness:transfer"],
+        exitConditions: [],
+      },
+    ],
+    transfers: [
+      {
+        id: "transfer:layout-binding",
+        responsibilityId: "responsibility:layout-binding",
+        fromCarrier: "caller",
+        toCarrier: "tranchnode",
+        sourceStageId: "stage-a",
+        destinationStageId: "stage-b",
+        requiredWitnessIds: ["witness:transfer"],
+        permitsShedding: ["dependency:caller-layout-ref"],
+      },
+    ],
+  };
+}
+
+test("continuity spine rejects unsupported schema versions", () => {
+  assert.throws(
+    () => validateContinuitySpineManifest({ schema: "tranchnode/continuity-spine/v9" }),
+    (error: unknown) => error instanceof ContinuitySpineError
+      && error.code === "UNSUPPORTED_SCHEMA_VERSION",
+  );
+});
+
+test("continuity spine rejects an attractor that impersonates constituted reality", () => {
+  const candidate = minimalManifest() as any;
+  candidate.attractor.status = "constituted";
+  assert.throws(
+    () => validateContinuitySpineManifest(candidate),
+    (error: unknown) => error instanceof ContinuitySpineError
+      && error.code === "ATTRACTOR_MUST_BE_PROPOSAL",
+  );
+});
+
+test("continuity spine rejects duplicate and incomplete stage order", () => {
+  const duplicate = minimalManifest() as any;
+  duplicate.stageOrder = ["stage-a", "stage-a"];
+  assert.throws(
+    () => validateContinuitySpineManifest(duplicate),
+    (error: unknown) => error instanceof ContinuitySpineError
+      && error.code === "INVALID_STAGE_ORDER",
+  );
+
+  const omitted = minimalManifest() as any;
+  omitted.stageOrder = ["stage-a"];
+  assert.throws(
+    () => validateContinuitySpineManifest(omitted),
+    (error: unknown) => error instanceof ContinuitySpineError
+      && error.code === "INVALID_STAGE_ORDER",
+  );
+});
+
+test("continuity spine validator returns a fresh normalized manifest", () => {
+  const input = minimalManifest();
+  const validated = validateContinuitySpineManifest(input);
+
+  assert.deepEqual(validated, input);
+  assert.notEqual(validated, input);
+  assert.notEqual(validated.stages, input.stages);
+  assert.notEqual(validated.stages[0], input.stages[0]);
+});

--- a/test/continuity-spine.test.ts
+++ b/test/continuity-spine.test.ts
@@ -136,7 +136,9 @@ test("witnessed transfer permits the declared scaffold to be shed", () => {
 
 test("proposal destination can be structurally admissible without becoming constituted", () => {
   const spine = minimalManifest();
-  spine.stages[1].status = "proposal";
+  const destination = spine.stages[1];
+  assert.ok(destination);
+  destination.status = "proposal";
   const result = evaluateStageTransition({
     spine,
     fromStageId: "stage-a",
@@ -163,7 +165,9 @@ test("missing transfer witness blocks a shed permitted by that transfer", () => 
 
 test("active invariant loss blocks the transition", () => {
   const spine = minimalManifest();
-  spine.stages[1].carries = spine.stages[1].carries.filter(
+  const destination = spine.stages[1];
+  assert.ok(destination);
+  destination.carries = destination.carries.filter(
     (id) => id !== "decoder-authority:none",
   );
   const result = evaluateStageTransition({

--- a/test/continuity-spine.test.ts
+++ b/test/continuity-spine.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
   ContinuitySpineError,
@@ -6,6 +7,12 @@ import {
   validateContinuitySpineManifest,
   type ContinuitySpineManifestV01,
 } from "../src/continuity-spine.js";
+
+const FIXTURE_PATH = "fixtures/continuity-spine/intent-stroke-v01-to-v02.json";
+
+async function rawFixture(): Promise<any> {
+  return JSON.parse(await readFile(FIXTURE_PATH, "utf8"));
+}
 
 function minimalManifest(): ContinuitySpineManifestV01 {
   return {
@@ -191,4 +198,117 @@ test("backward transition is invalid rather than merely blocked", () => {
 
   assert.equal(result.decision, "invalid");
   assert.ok(result.findings.some((finding) => finding.class === "invalid_manifest"));
+});
+
+test("Intent Stroke v0.1 -> v0.2 proves overlap, witnessed transfer, and lawful shedding", async () => {
+  const spine = validateContinuitySpineManifest(await rawFixture());
+  const result = evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:pr54-boundary-review"],
+  });
+
+  assert.equal(result.decision, "admissible");
+  assert.deepEqual(result.shed, ["dependency:caller-constructs-fieldLayoutRef"]);
+  assert.deepEqual(
+    result.completedTransferIds,
+    ["transfer:canonical-layout-binding-to-tranchnode"],
+  );
+  assert.equal(
+    result.findings.some((finding) => finding.class.startsWith("blocked_")),
+    false,
+  );
+});
+
+test("Intent Stroke transfer witness is required before caller layout binding may be shed", async () => {
+  const spine = validateContinuitySpineManifest(await rawFixture());
+  const result = evaluateStageTransition({
+    spine,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: [],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_unwitnessed_transfer"));
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_premature_shedding"));
+});
+
+test("Intent Stroke destination cannot drop decoder non-authority", async () => {
+  const candidate = await rawFixture();
+  const destination = candidate.stages.find(
+    (stage: any) => stage.id === "v0.1-v0.2-overlap",
+  );
+  assert.ok(destination);
+  destination.carries = destination.carries.filter(
+    (id: string) => id !== "decoder-authority:none",
+  );
+  const result = evaluateStageTransition({
+    spine: candidate,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:pr54-boundary-review"],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_invariant_loss"));
+});
+
+test("Intent Stroke attractor cannot become constituted merely because it is desired", async () => {
+  const candidate = await rawFixture();
+  candidate.attractor.status = "constituted";
+
+  assert.throws(
+    () => validateContinuitySpineManifest(candidate),
+    (error: unknown) => error instanceof ContinuitySpineError
+      && error.code === "ATTRACTOR_MUST_BE_PROPOSAL",
+  );
+});
+
+test("Intent Stroke overlap must preserve the v0.1 compatibility obligation", async () => {
+  const candidate = await rawFixture();
+  const destination = candidate.stages.find(
+    (stage: any) => stage.id === "v0.1-v0.2-overlap",
+  );
+  assert.ok(destination);
+  destination.carries = destination.carries.filter(
+    (id: string) => id !== "interface:intent-stroke-stdio-v0.1",
+  );
+  const result = evaluateStageTransition({
+    spine: candidate,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: ["witness:pr54-green", "witness:pr54-boundary-review"],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_invariant_loss"));
+});
+
+test("Intent Stroke refuses to drop responsibility when no transfer carries it forward", async () => {
+  const candidate = await rawFixture();
+  const destination = candidate.stages.find(
+    (stage: any) => stage.id === "v0.1-v0.2-overlap",
+  );
+  assert.ok(destination);
+  destination.carries = destination.carries.filter(
+    (id: string) => id !== "responsibility:canonical-layout-binding",
+  );
+  candidate.transfers = [];
+
+  const result = evaluateStageTransition({
+    spine: candidate,
+    fromStageId: "v0.1-caller-bound",
+    toStageId: "v0.1-v0.2-overlap",
+    suppliedWitnesses: [],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(
+    result.findings.some(
+      (finding) => finding.class === "blocked_untransferred_responsibility"
+        && finding.reason === "RESPONSIBILITY_DROPPED_WITHOUT_TRANSFER",
+    ),
+  );
 });

--- a/test/continuity-spine.test.ts
+++ b/test/continuity-spine.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ContinuitySpineError,
+  evaluateStageTransition,
   validateContinuitySpineManifest,
   type ContinuitySpineManifestV01,
 } from "../src/continuity-spine.js";
@@ -117,4 +118,73 @@ test("continuity spine validator returns a fresh normalized manifest", () => {
   assert.notEqual(validated, input);
   assert.notEqual(validated.stages, input.stages);
   assert.notEqual(validated.stages[0], input.stages[0]);
+});
+
+test("witnessed transfer permits the declared scaffold to be shed", () => {
+  const result = evaluateStageTransition({
+    spine: minimalManifest(),
+    fromStageId: "stage-a",
+    toStageId: "stage-b",
+    suppliedWitnesses: ["witness:transfer"],
+  });
+
+  assert.equal(result.decision, "admissible");
+  assert.deepEqual(result.shed, ["dependency:caller-layout-ref"]);
+  assert.deepEqual(result.completedTransferIds, ["transfer:layout-binding"]);
+  assert.deepEqual(result.findings, []);
+});
+
+test("proposal destination can be structurally admissible without becoming constituted", () => {
+  const spine = minimalManifest();
+  spine.stages[1].status = "proposal";
+  const result = evaluateStageTransition({
+    spine,
+    fromStageId: "stage-a",
+    toStageId: "stage-b",
+    suppliedWitnesses: ["witness:transfer"],
+  });
+
+  assert.equal(result.decision, "admissible");
+  assert.ok(result.findings.some((finding) => finding.class === "proposal_only"));
+});
+
+test("missing transfer witness blocks a shed permitted by that transfer", () => {
+  const result = evaluateStageTransition({
+    spine: minimalManifest(),
+    fromStageId: "stage-a",
+    toStageId: "stage-b",
+    suppliedWitnesses: [],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_unwitnessed_transfer"));
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_premature_shedding"));
+});
+
+test("active invariant loss blocks the transition", () => {
+  const spine = minimalManifest();
+  spine.stages[1].carries = spine.stages[1].carries.filter(
+    (id) => id !== "decoder-authority:none",
+  );
+  const result = evaluateStageTransition({
+    spine,
+    fromStageId: "stage-a",
+    toStageId: "stage-b",
+    suppliedWitnesses: ["witness:transfer"],
+  });
+
+  assert.equal(result.decision, "blocked");
+  assert.ok(result.findings.some((finding) => finding.class === "blocked_invariant_loss"));
+});
+
+test("backward transition is invalid rather than merely blocked", () => {
+  const result = evaluateStageTransition({
+    spine: minimalManifest(),
+    fromStageId: "stage-b",
+    toStageId: "stage-a",
+    suppliedWitnesses: [],
+  });
+
+  assert.equal(result.decision, "invalid");
+  assert.ok(result.findings.some((finding) => finding.class === "invalid_manifest"));
 });


### PR DESCRIPTION
## Purpose

Implements #56 from the approved Continuity Spine v0.1 design and implementation plan.

This PR proves one bounded transformation vertical:

- strict `tranchnode/continuity-spine/v0.1` manifest;
- explicit forward stage ordering;
- proposal-only attractor;
- invariant survival through declared carrier requirements;
- overlap before replacement;
- witness-gated responsibility transfer;
- lawful shedding only after transfer;
- fail-closed unknown witness handling;
- deterministic, non-mutating evaluation;
- pinned Intent Stroke v0.1 → v0.2 specimen from PR #54.

## TDD evidence

The branch was built through explicit RED → GREEN gates in GitHub Actions:

1. **Manifest RED** — run #77 (`32285068271`) failed because `src/continuity-spine.ts` did not exist.
2. **Manifest characterization repair** — run #78 exposed the stage-order reason-code mismatch; the validator was tightened rather than weakening the test.
3. **Manifest GREEN** — run #79 passed.
4. **Evaluator RED** — run #81 failed only on the five new transition tests because `evaluateStageTransition` returned `NOT_IMPLEMENTED`; the rest of the suite remained green.
5. **Evaluator GREEN** — run #82 passed.
6. **Real-specimen RED** — run #83 failed only because `fixtures/continuity-spine/intent-stroke-v01-to-v02.json` was intentionally absent; the prior 102 tests passed.
7. **Real-specimen GREEN** — run #84 passed.
8. **Hardening GREEN** — exact-head run #85 (`32286047999`) passed `npm run check` with **112/112 tests**.

Exact reviewed head: `7a1b28aa7f2c7492d14653f65d729ec9fedd1a4b`.

## Exact-head review

Owner/Riqor boundary review was performed on the exact head. The changed-file set is exactly:

- `src/continuity-spine.ts`
- `fixtures/continuity-spine/intent-stroke-v01-to-v02.json`
- `test/continuity-spine.test.ts`

No remaining correctness or authority-boundary issue was found for the approved v0.1 slice.

## Boundaries

This PR does **not** modify `PROJECT_STATUS.json`, `ONTOLOGY.md`, `src/intent-stroke.ts`, or `scripts/intent-stroke-stdio.ts` and adds no scheduler/orchestrator, network/API runtime, automatic deletion, future-state promotion, or cross-repository schema propagation.

The evaluator describes and refuses transformations; it does not execute them.

Closes #56.