### PR TITLE
docs: reconcile Aug 19 executable status

### DIFF
--- a/PROJECT_STATUS.json
+++ b/PROJECT_STATUS.json
@@ -1,22 +1,25 @@
 {
   "schema": "static-collective.project-status.v1",
-  "asOf": "2026-08-17",
+  "asOf": "2026-08-19",
   "repository": "the-static-collective/tranchnode",
   "defaultBranch": "main",
   "project": "TranchNode",
   "state": "active",
-  "phase": "Intent Stroke v0.2 process boundary",
+  "phase": "Intent Stroke v0.2 process boundary + Continuity Spine v0.1",
   "canonicalAuthority": "project-owned repository",
-  "observedMainCommit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197",
+  "observedMainCommit": "ca32f69d63cfd1ef0e8ae70c73186bbe46968f9d",
   "executableSurface": [
     {"id": "residual-v0.1", "status": "landed", "interface": "TypeScript library/tests"},
     {"id": "intent-stroke-decoder-v0.1", "status": "landed", "evidence": {"commit": "efc75f6228a2d9c16475378d0dc382a48bf762c8", "pullRequest": 41}},
     {"id": "intent-stroke-stdio-v0.1", "status": "landed", "evidence": {"commit": "a3dc7fa5155df93641f4f116eac1464b10342849", "pullRequest": 50}},
-    {"id": "intent-stroke-stdio-v0.2-raw-points", "status": "landed", "interface": "npm run intent-stroke:stdio", "evidence": {"commit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197", "pullRequest": 54}}
+    {"id": "intent-stroke-stdio-v0.2-raw-points", "status": "landed", "interface": "npm run intent-stroke:stdio", "evidence": {"commit": "bf886c0b4938a1444a79afb7a7b384e91b5d5197", "pullRequest": 54}},
+    {"id": "continuity-spine-v0.1", "status": "landed", "interface": "pure TypeScript transition evaluator + pinned Intent Stroke v0.1-to-v0.2 specimen", "evidence": {"commit": "ca32f69d63cfd1ef0e8ae70c73186bbe46968f9d", "pullRequest": 58}}
   ],
   "nonClaims": [
     "retrieval is not authority",
     "decoded intent does not authorize traversal",
-    "raw pointer transport does not transfer caller authority"
+    "raw pointer transport does not transfer caller authority",
+    "Continuity Spine describes and refuses staged transitions; it does not execute them or promote proposed futures into present state",
+    "witnessed transfer is required before lawful shedding"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ It includes:
 - TypeScript residual extraction and validation;
 - **Intent Stroke v0.1** traversal decoding with deterministic candidate/ambiguity evidence;
 - a bounded stdio process adapter for Intent Stroke;
-- **Intent Stroke stdio v0.2**, which accepts raw pointer points and binds them to the donor-owned canonical field layout before decoding.
+- **Intent Stroke stdio v0.2**, which accepts raw pointer points and binds them to the donor-owned canonical field layout before decoding;
+- **Continuity Spine v0.1**, a pure staged-transformation evaluator that keeps future attractors proposal-only, requires invariant-preserving overlap and witnessed responsibility transfer, and permits shedding only after the receiving carrier demonstrably bears the dependency.
 
 The process seam deliberately carries observation, not crossing authority. A decoded gesture may expose a candidate route; it does not authorize the destination or silently choose a crossing.
+
+Continuity Spine likewise describes and refuses transitions; it does not execute them. Its first pinned specimen treats the Intent Stroke v0.1 → v0.2 change as a staged handoff rather than rewriting the older carrier out of history.
 
 Run the complete repository proof:
 
@@ -71,6 +74,6 @@ Applications are replaceable interfaces. Retrieval proposes relevant material. M
 
 ## Status
 
-TranchNode is under active development. The repository contains both adopted architectural law and bounded executable proofs. Its newest process-facing proof turns raw human traversal input into deterministic, inspectable candidate evidence while leaving destination authority outside the decoder.
+TranchNode is under active development. The repository contains both adopted architectural law and bounded executable proofs. Its process-facing proof turns raw human traversal input into deterministic, inspectable candidate evidence while leaving destination authority outside the decoder; its Continuity Spine proof now separately demonstrates staged transformation without promoting desired futures into present fact.
 
 Historical proposals should be read through their inheritance and supersession links rather than assumed to be live integration choices.


### PR DESCRIPTION
## Summary

Reconcile TranchNode's README and machine status with current `main` after Continuity Spine v0.1 landed.

- advance observed main to `ca32f69d...`;
- add Continuity Spine v0.1 to `PROJECT_STATUS.json`;
- expose the staged-transformation proof from the README front door;
- preserve the boundary that the Spine describes/refuses transitions but does not execute them or promote proposed futures into present state.

Documentation/metadata only; no executable semantics change.