### PR TITLE
docs: add Tranchish decompression lab

### DIFF
--- a/docs/TRANCHISH_DECOMPRESSION_LAB.md
+++ b/docs/TRANCHISH_DECOMPRESSION_LAB.md
@@ -1,0 +1,290 @@
+# Tranchish Decompression Lab — sound → name → world
+
+**Status:** bounded design probe / no runtime authority  
+**Issue:** #63  
+**Research source:** National Treasure `cases/selador/tolkien-language-decompression.md`  
+**Neighbor:** `docs/TRANCHISH_V0_SPIKE.md`
+
+## Question
+
+Can Tranchish become more alive by allowing meaningful language to **decompress through use** without weakening the deterministic boundary required for executable Canonical Tranchish?
+
+The research trigger is Tolkien's glossopoeic practice: sound-form, names, mythology, internal history, speaker communities, translation, and script were allowed to grow together rather than being treated as isolated dictionary entries.
+
+For this project, **decompression** is a Static Collective analytical term. It is not attributed to Tolkien.
+
+## The transfer we actually want
+
+Not:
+
+```text
+beautiful sound
+  -> true meaning
+  -> executable command
+```
+
+But:
+
+```text
+resonant form
+  -> Wild Tranchish candidate
+  -> repeated human use
+  -> witnessed semantic growth / mutation
+  -> optional canonicalization proposal
+```
+
+while the executable path remains:
+
+```text
+canonical sentence
+  -> deterministic parse
+  -> typed proposal
+  -> separately constituted authority
+  -> consequence / refusal / failure
+  -> receipt
+```
+
+The two paths may meet only at an explicit canonicalization boundary.
+
+## Research-derived pressures
+
+### 1. Sound may precede settled meaning
+
+Tolkien's `cellar door` discussion and the reported `Selador` process anecdote both support attention to sound-form before ordinary semantic closure.
+
+For Tranchish:
+
+> A wild word is allowed to exist before the system knows exactly what it means.
+
+That does **not** make it executable.
+
+### 2. Names can attract situations and worlds
+
+Tolkien repeatedly described language invention as foundational to his stories and said that, for him, a name comes first and the story follows.
+
+For Tranchish, a coined form may therefore become a useful attractor for:
+
+- a UI metaphor;
+- a project behavior;
+- a social convention;
+- a category of residue;
+- a repeated workflow;
+- a previously unnamed distinction.
+
+The attracted structure remains descriptive until separately adopted.
+
+### 3. Words should have ancestry, not only definitions
+
+Tolkien's related language forms and systematic sound changes suggest that a lexicon can preserve **diachrony**.
+
+A Tranchish entry should eventually be able to answer:
+
+```text
+where did this form appear?
+what did it mean there?
+what mutated?
+who reused it?
+what meanings branched?
+what survived?
+```
+
+No silent overwrite.
+
+### 4. Speaker ecology is part of language life
+
+Tolkien's languages belong to different peoples, histories, prestige systems, secrets, regions, and periods.
+
+Tranchish should not pretend every form is universal merely because several agents can parse it.
+
+A word may have:
+
+```text
+project-local use
+human-local use
+model-local paraphrase
+joke use
+technical use
+ritual / mnemonic use
+canonical executable use
+```
+
+Those roles must remain distinguishable.
+
+### 5. Representation is not identity
+
+Tolkien's translation conceit — English representing Westron, Old English representing Rohirric relations — is a useful analogue for TranchNode.
+
+A human-facing sentence, a typed parse, and a receipt may preserve a lawful relation without becoming one artifact.
+
+```text
+spoken form
+  != typed structure
+  != authority
+  != receipt
+```
+
+Round-trip legibility is the goal; collapse is not.
+
+## Wild Decompression record
+
+The smallest useful record for a Wild Tranchish form:
+
+```text
+form
+first_attested_use
+speaker_or_source
+context
+sound_or_source_resonance
+felt_meaning_at_use
+work_done_by_word
+variants
+misunderstandings
+semantic_branches
+repeated_uses
+candidate_semantic_core
+canonicalization_status
+```
+
+No field above grants authority.
+
+## First specimen — Selador
+
+Current posture:
+
+```text
+form: Selador
+status: wild
+canonical_meaning: none
+execution_mapping: none
+```
+
+Observed local pressure already includes several possible senses:
+
+- threshold into compressed beauty;
+- sound escaping ordinary spelling;
+- opening from canonical machinery into linguistic play;
+- a mnemonic for the non-executable living side of Tranchish.
+
+Do not choose among these yet.
+
+The experiment is to watch which meanings recur and what work the word starts doing.
+
+## Decompression is not canonicalization
+
+These must remain separate operations.
+
+### Decompression
+
+```text
+small form
+  -> more associations / relations / uses / descendants
+```
+
+May increase ambiguity.
+
+May branch.
+
+May be poetic.
+
+May remain unresolved indefinitely.
+
+### Canonicalization
+
+```text
+candidate meaning
+  -> one inspectable normalized semantic contract
+```
+
+Must reduce ambiguity.
+
+Must fail closed when multiple meanings remain materially valid.
+
+May create an executable alias/root only after separate specification and proof.
+
+Therefore:
+
+> **Wild Tranchish can become richer by branching. Canonical Tranchish becomes safer by narrowing.**
+
+## Phonaesthetics boundary
+
+Aesthetic preference may influence candidate generation:
+
+```text
+pleasant / striking / memorable sound
+  -> worth trying in speech
+```
+
+It may never imply:
+
+```text
+pleasant sound
+  -> intrinsic meaning
+  -> truth
+  -> authority
+```
+
+No aesthetic score belongs in admission, warrant, or consequence logic.
+
+## Historical layers without fake history
+
+Tolkien deliberately built fictional ancestry into invented languages.
+
+Tranchish can learn from the *structure* without laundering invented backstory into evidence.
+
+Two different histories may exist:
+
+```text
+design fiction
+  = deliberately invented proto-forms / worldbuilding
+
+attested history
+  = actual recorded uses, mutations, adoptions, refusals
+```
+
+They must be labeled separately.
+
+Actual language life should be derived from the second.
+
+## Smallest next proof
+
+Do not build a parser for this.
+
+Run a usage witness over 3–5 Wild Tranchish forms for several real project conversations.
+
+At minimum include:
+
+```text
+Selador
+inslice
+deephaunt
+```
+
+The remaining forms can be chosen from naturally occurring vocabulary rather than invented solely for the experiment.
+
+Success conditions:
+
+1. at least one term acquires a recurring useful distinction without a definition being imposed first;
+2. at least one term branches into multiple live meanings and the record preserves both;
+3. at least one attractive term fails to recur and remains a dead/ornamental branch;
+4. no wild term becomes executable merely through frequency or model familiarity;
+5. a later reader can reconstruct how the term changed from the recorded specimens.
+
+## Non-goals
+
+- no Tolkien vocabulary imported into Canonical Tranchish;
+- no imitation requirement for Quenya, Sindarin, Tengwar, or any Tolkien morphology;
+- no universal beauty claim;
+- no sound-symbolism claim that phonemes inherently encode concepts;
+- no runtime parser changes;
+- no authority semantics changes;
+- no automatic promotion by usage counts;
+- no synthetic antiquity represented as actual project history;
+- no replacement for the Cellar Door deterministic fixture family.
+
+## Governing compression
+
+> **Let sound open possibility. Let use decompress meaning. Let canon wait for evidence.**
+
+Or, paired with the first Tranchish law:
+
+> **Keep the machine exact. Let the language breathe.**


### PR DESCRIPTION
## Summary

Adds a bounded Tranchish design probe derived from the Tolkien language-making research without promoting Tolkien lore, vocabulary, or phonaesthetic preference into executable semantics.

Closes #63 only as a documentation spike if the project accepts the lab note as sufficient preservation; no parser/runtime work is claimed.

## What this adds

- `docs/TRANCHISH_DECOMPRESSION_LAB.md`

The lab separates two paths:

```text
resonant form -> Wild Tranchish -> usage -> mutation -> optional canonicalization proposal
```

from:

```text
canonical sentence -> deterministic parse -> typed proposal -> authority -> terminal receipt
```

The core rule is that the paths may meet only at an explicit canonicalization boundary.

## Research-derived pressures

- sound may precede settled meaning in the wild membrane;
- names may attract situations/worlds without gaining authority;
- lexical ancestry and semantic drift should remain inspectable;
- speaker ecology/register can be preserved without universalizing every form;
- human-facing representation, typed parse, authority, and receipt remain distinct artifacts;
- decompression may increase ambiguity, while canonicalization must reduce it.

## First proposed witness

Observe 3–5 naturally occurring Wild Tranchish forms, including `Selador`, `inslice`, and `deephaunt`, and record first use, context, mutations, competing meanings, recurrence, and whether a stable semantic center actually emerges.

## Non-goals

No runtime changes, no parser changes, no authority changes, no Tolkien-derived vocabulary imports, no sound-symbolism truth claims, and no automatic canonization by frequency/model familiarity.

## Governing compression

> **Let sound open possibility. Let use decompress meaning. Let canon wait for evidence.**